### PR TITLE
feat: FFT-based high-frequency detector with hold-off (#2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ rust-version = "1.78.0"
 
 [dependencies]
 getrandom = "0.2"
+rustfft = "6"

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -66,20 +66,53 @@ impl AudioSource for SineSource {
     }
 }
 
-/// Pulls samples from an [`AudioSource`] for downstream analysis.
+const FFT_SIZE: usize = 2048;
+const TRIGGER_BAND_HZ: (f32, f32) = (19_000.0, 20_500.0);
+/// Pure 19 kHz @ amp 0.5 yields band power around 262_144; threshold sits well below that.
+const POWER_THRESHOLD: f32 = 10_000.0;
+/// ~128 ms at 48 kHz with 2048-sample windows.
+const STREAK_TO_FLIP: u32 = 3;
+
+/// Pulls samples from an [`AudioSource`] and detects ultrasonic trigger tones.
 ///
-/// Note: the derived `Debug` and `Clone` impls add hidden `S: Debug + Clone`
-/// bounds. Sources that hold non-cloneable resources (e.g. a future cpal
-/// stream handle in #3) may need manual impls instead.
-#[derive(Debug, Clone)]
+/// Note: `Debug` is hand-implemented because the boxed FFT trait object is
+/// not itself `Debug`. `Clone` is not implemented because the FFT planner
+/// state is not naturally cloneable; sources that hold non-cloneable
+/// resources (e.g. a future cpal stream handle in #3) compose cleanly with
+/// this.
 pub struct Detector<S: AudioSource> {
     source: S,
+    fft: std::sync::Arc<dyn rustfft::Fft<f32>>,
+    scratch: Vec<rustfft::num_complex::Complex<f32>>,
+    high_streak: u32,
+    low_streak: u32,
+    compromised: bool,
+}
+
+impl<S: AudioSource + core::fmt::Debug> core::fmt::Debug for Detector<S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Detector")
+            .field("source", &self.source)
+            .field("high_streak", &self.high_streak)
+            .field("low_streak", &self.low_streak)
+            .field("compromised", &self.compromised)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<S: AudioSource> Detector<S> {
     /// Constructs a detector that reads from `source`.
     pub fn with_source(source: S) -> Self {
-        Self { source }
+        let mut planner = rustfft::FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(FFT_SIZE);
+        Self {
+            source,
+            fft,
+            scratch: vec![rustfft::num_complex::Complex::new(0.0, 0.0); FFT_SIZE],
+            high_streak: 0,
+            low_streak: 0,
+            compromised: false,
+        }
     }
 
     /// Returns the underlying source's sample rate in Hz.
@@ -87,9 +120,55 @@ impl<S: AudioSource> Detector<S> {
         self.source.sample_rate()
     }
 
-    /// Reads samples from the underlying source into `buf`.
+    /// Reads samples from the underlying source into `buf`. Does not advance FFT state — call `poll` for that.
     pub fn read(&mut self, buf: &mut [f32]) -> usize {
         self.source.read(buf)
+    }
+
+    /// Pulls one FFT window worth of samples, runs an FFT, updates the compromised flag, and returns it.
+    pub fn poll(&mut self) -> bool {
+        let mut buf = vec![0.0f32; FFT_SIZE];
+        let n = self.source.read(&mut buf);
+        for (slot, sample) in self.scratch.iter_mut().zip(buf.iter()) {
+            *slot = rustfft::num_complex::Complex::new(*sample, 0.0);
+        }
+        if n < FFT_SIZE {
+            for slot in &mut self.scratch[n..] {
+                *slot = rustfft::num_complex::Complex::new(0.0, 0.0);
+            }
+        }
+        self.fft.process(&mut self.scratch);
+
+        let band_power = self.band_power();
+        if band_power >= POWER_THRESHOLD {
+            self.high_streak = self.high_streak.saturating_add(1);
+            self.low_streak = 0;
+            if self.high_streak >= STREAK_TO_FLIP {
+                self.compromised = true;
+            }
+        } else {
+            self.low_streak = self.low_streak.saturating_add(1);
+            self.high_streak = 0;
+            if self.low_streak >= STREAK_TO_FLIP {
+                self.compromised = false;
+            }
+        }
+        self.compromised
+    }
+
+    /// Returns whether the detector is currently flagging a trigger condition.
+    pub fn is_compromised(&self) -> bool {
+        self.compromised
+    }
+
+    fn band_power(&self) -> f32 {
+        let bin_hz = self.source.sample_rate() as f32 / FFT_SIZE as f32;
+        let lo_bin = (TRIGGER_BAND_HZ.0 / bin_hz).floor() as usize;
+        let hi_bin = ((TRIGGER_BAND_HZ.1 / bin_hz).ceil() as usize).min(FFT_SIZE / 2);
+        self.scratch[lo_bin..=hi_bin]
+            .iter()
+            .map(|c| c.norm_sqr())
+            .sum()
     }
 }
 
@@ -129,6 +208,110 @@ mod tests {
         for i in 0..256 {
             assert!((b[i] - combined[i + 256]).abs() < 1e-6);
         }
+    }
+
+    /// A `Vec<f32>`-backed source that yields pre-scripted samples in chunks.
+    struct ScriptedSource {
+        samples: Vec<f32>,
+        cursor: usize,
+        sample_rate: u32,
+    }
+
+    impl ScriptedSource {
+        fn new(samples: Vec<f32>, sample_rate: u32) -> Self {
+            Self {
+                samples,
+                cursor: 0,
+                sample_rate,
+            }
+        }
+    }
+
+    impl AudioSource for ScriptedSource {
+        fn sample_rate(&self) -> u32 {
+            self.sample_rate
+        }
+
+        fn read(&mut self, buf: &mut [f32]) -> usize {
+            let remaining = self.samples.len().saturating_sub(self.cursor);
+            let n = remaining.min(buf.len());
+            buf[..n].copy_from_slice(&self.samples[self.cursor..self.cursor + n]);
+            self.cursor += n;
+            for slot in &mut buf[n..] {
+                *slot = 0.0;
+            }
+            n
+        }
+    }
+
+    fn sine_window(frequency: f32, amplitude: f32, sample_rate: u32, len: usize) -> Vec<f32> {
+        let mut src = SineSource::with_sample_rate(frequency, amplitude, sample_rate);
+        let mut buf = vec![0.0f32; len];
+        src.read(&mut buf);
+        buf
+    }
+
+    #[test]
+    fn detector_flags_compromised_under_19khz_tone() {
+        let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
+        let mut flipped = false;
+        for _ in 0..24 {
+            if detector.poll() {
+                flipped = true;
+                break;
+            }
+        }
+        assert!(flipped, "detector did not flip under sustained 19 kHz tone");
+        assert!(detector.is_compromised());
+    }
+
+    #[test]
+    fn detector_stays_uncompromised_under_1khz_tone() {
+        let mut detector = Detector::with_source(SineSource::new(1_000.0, 0.5));
+        for _ in 0..24 {
+            detector.poll();
+            assert!(
+                !detector.is_compromised(),
+                "1 kHz tone should not flip the detector"
+            );
+        }
+    }
+
+    #[test]
+    fn detector_does_not_flip_on_single_window_spike() {
+        let mut samples = sine_window(19_000.0, 0.5, 48_000, FFT_SIZE);
+        samples.extend(vec![0.0f32; FFT_SIZE * 10]);
+        let source = ScriptedSource::new(samples, 48_000);
+        let mut detector = Detector::with_source(source);
+        for _ in 0..11 {
+            detector.poll();
+            assert!(
+                !detector.is_compromised(),
+                "single-window spike should not flip the detector"
+            );
+        }
+    }
+
+    #[test]
+    fn detector_recovers_after_tone_stops() {
+        let mut samples = sine_window(19_000.0, 0.5, 48_000, FFT_SIZE * 5);
+        samples.extend(vec![0.0f32; FFT_SIZE * 5]);
+        let source = ScriptedSource::new(samples, 48_000);
+        let mut detector = Detector::with_source(source);
+        for _ in 0..5 {
+            detector.poll();
+        }
+        assert!(
+            detector.is_compromised(),
+            "tone phase should flip the detector to true"
+        );
+        for _ in 0..5 {
+            detector.poll();
+        }
+        assert!(
+            !detector.is_compromised(),
+            "silence phase should flip the detector back to false"
+        );
     }
 
     #[test]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,12 +1,13 @@
 //! Audio input abstraction and a sine-wave test fixture.
 //!
 //! ```
-//! use hoba::audio::{AudioSource, Detector, SineSource};
+//! use hoba::audio::{Detector, SineSource};
 //!
 //! let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
-//! let mut buf = [0.0f32; 1024];
-//! let n = detector.read(&mut buf);
-//! assert_eq!(n, buf.len());
+//! for _ in 0..12 {
+//!     detector.poll();
+//! }
+//! assert!(detector.is_compromised());
 //! ```
 
 use core::f64::consts::TAU;
@@ -66,11 +67,14 @@ impl AudioSource for SineSource {
     }
 }
 
+/// 2048-point FFT: bin width 23.4 Hz at 48 kHz, ~810 cycles of a 19 kHz tone per window.
 const FFT_SIZE: usize = 2048;
+/// Trigger band, widened by `floor`/`ceil` to capture leakage at the edges. See `Detector::band_power`.
 const TRIGGER_BAND_HZ: (f32, f32) = (19_000.0, 20_500.0);
-/// Pure 19 kHz @ amp 0.5 yields band power around 262_144; threshold sits well below that.
+/// Calibrated against `detector_flags_compromised_under_19khz_tone`: pure 19 kHz @ amp 0.5
+/// produces band power ~262_144 with rectangular-window leakage. Threshold sits ~26x below.
 const POWER_THRESHOLD: f32 = 10_000.0;
-/// ~128 ms at 48 kHz with 2048-sample windows.
+/// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
 const STREAK_TO_FLIP: u32 = 3;
 
 /// Pulls samples from an [`AudioSource`] and detects ultrasonic trigger tones.
@@ -80,10 +84,16 @@ const STREAK_TO_FLIP: u32 = 3;
 /// state is not naturally cloneable; sources that hold non-cloneable
 /// resources (e.g. a future cpal stream handle in #3) compose cleanly with
 /// this.
+///
+/// The trigger band is approximate. Rectangular-window leakage means tones
+/// just outside 19.0–20.5 kHz (within ~50 Hz) still flip the flag. For an
+/// "is the environment ultrasonic" check this is desirable; for narrowband
+/// classification, post-process the FFT separately.
 pub struct Detector<S: AudioSource> {
     source: S,
     fft: std::sync::Arc<dyn rustfft::Fft<f32>>,
     scratch: Vec<rustfft::num_complex::Complex<f32>>,
+    pull_buf: Vec<f32>,
     high_streak: u32,
     low_streak: u32,
     compromised: bool,
@@ -109,6 +119,7 @@ impl<S: AudioSource> Detector<S> {
             source,
             fft,
             scratch: vec![rustfft::num_complex::Complex::new(0.0, 0.0); FFT_SIZE],
+            pull_buf: vec![0.0f32; FFT_SIZE],
             high_streak: 0,
             low_streak: 0,
             compromised: false,
@@ -120,16 +131,13 @@ impl<S: AudioSource> Detector<S> {
         self.source.sample_rate()
     }
 
-    /// Reads samples from the underlying source into `buf`. Does not advance FFT state — call `poll` for that.
-    pub fn read(&mut self, buf: &mut [f32]) -> usize {
-        self.source.read(buf)
-    }
-
-    /// Pulls one FFT window worth of samples, runs an FFT, updates the compromised flag, and returns it.
-    pub fn poll(&mut self) -> bool {
-        let mut buf = vec![0.0f32; FFT_SIZE];
-        let n = self.source.read(&mut buf);
-        for (slot, sample) in self.scratch.iter_mut().zip(buf.iter()) {
+    /// Pulls one FFT window worth of samples, runs an FFT, and updates the compromised flag.
+    pub fn poll(&mut self) {
+        for slot in &mut self.pull_buf {
+            *slot = 0.0;
+        }
+        let n = self.source.read(&mut self.pull_buf);
+        for (slot, sample) in self.scratch.iter_mut().zip(self.pull_buf.iter()) {
             *slot = rustfft::num_complex::Complex::new(*sample, 0.0);
         }
         if n < FFT_SIZE {
@@ -153,7 +161,6 @@ impl<S: AudioSource> Detector<S> {
                 self.compromised = false;
             }
         }
-        self.compromised
     }
 
     /// Returns whether the detector is currently flagging a trigger condition.
@@ -162,9 +169,13 @@ impl<S: AudioSource> Detector<S> {
     }
 
     fn band_power(&self) -> f32 {
-        let bin_hz = self.source.sample_rate() as f32 / FFT_SIZE as f32;
-        let lo_bin = (TRIGGER_BAND_HZ.0 / bin_hz).floor() as usize;
-        let hi_bin = ((TRIGGER_BAND_HZ.1 / bin_hz).ceil() as usize).min(FFT_SIZE / 2);
+        let nyquist_bin = FFT_SIZE / 2;
+        let bin_hz = f64::from(self.source.sample_rate()) / FFT_SIZE as f64;
+        let lo_bin = ((f64::from(TRIGGER_BAND_HZ.0) / bin_hz).floor() as usize).min(nyquist_bin);
+        let hi_bin = ((f64::from(TRIGGER_BAND_HZ.1) / bin_hz).ceil() as usize).min(nyquist_bin);
+        if lo_bin > hi_bin {
+            return 0.0;
+        }
         self.scratch[lo_bin..=hi_bin]
             .iter()
             .map(|c| c.norm_sqr())
@@ -177,12 +188,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn detector_pulls_samples_from_sine_source() {
-        let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
-        let mut buf = [0.0f32; 1024];
-        let n = detector.read(&mut buf);
-        assert_eq!(n, 1024);
-        assert!(buf.iter().any(|s| *s != 0.0));
+    fn detector_constructible_from_sine_source() {
+        let detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
+        assert_eq!(detector.sample_rate(), 48_000);
+        assert!(!detector.is_compromised());
     }
 
     #[test]
@@ -255,14 +264,17 @@ mod tests {
     fn detector_flags_compromised_under_19khz_tone() {
         let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
         let mut flipped = false;
-        for _ in 0..24 {
-            if detector.poll() {
+        for _ in 0..12 {
+            detector.poll();
+            if detector.is_compromised() {
                 flipped = true;
                 break;
             }
         }
-        assert!(flipped, "detector did not flip under sustained 19 kHz tone");
-        assert!(detector.is_compromised());
+        assert!(
+            flipped,
+            "detector did not flip within ~500 ms under sustained 19 kHz tone"
+        );
     }
 
     #[test]
@@ -278,16 +290,16 @@ mod tests {
     }
 
     #[test]
-    fn detector_does_not_flip_on_single_window_spike() {
-        let mut samples = sine_window(19_000.0, 0.5, 48_000, FFT_SIZE);
+    fn detector_does_not_flip_just_below_streak_threshold() {
+        let mut samples = sine_window(19_000.0, 0.5, 48_000, FFT_SIZE * 2);
         samples.extend(vec![0.0f32; FFT_SIZE * 10]);
         let source = ScriptedSource::new(samples, 48_000);
         let mut detector = Detector::with_source(source);
-        for _ in 0..11 {
+        for _ in 0..12 {
             detector.poll();
             assert!(
                 !detector.is_compromised(),
-                "single-window spike should not flip the detector"
+                "2-window burst (streak=2 < 3) should not flip the detector"
             );
         }
     }


### PR DESCRIPTION
## 関連 Issue
closes #2

## 経緯
- 元 PR #16 は #15 (Issue #1) に積んだスタック PR でした
- #15 が squash merge されたため base ブランチが消え、stacked PR を main に rebase する必要が生じました
- force-push がハーネスで拒否されたため、main 起点の fresh branch で再 push（#16 はクローズ）
- レビュー履歴は freeza 側のセッションノートに記録、PR としては仕切り直し

## 変更内容

19–20.5 kHz 帯域のトリガートーン検出器を実装。

- `rustfft = "6"` 依存追加
- `Detector<S>` を拡張: 2048-sample FFT planner + 再利用 scratch + pull_buf + ホールドオフ状態
- `Detector::poll()` — 1 window 分の samples を source から pull、FFT、バンドパワー判定、フラグ更新
- `Detector::is_compromised()` — 現フラグ取得（single source of truth）
- 3-window streak ホールドオフ（~128 ms @ 48 kHz）で単発スパイクを無視
- pure 19 kHz @ amp 0.5 のバンドパワー ≈ 262 144 に対し閾値 10 000（一桁余裕）
- `Detector::read()` は #16 レビューで footgun 認定 → 削除（FFT state を bypass する API は持たない）
- `Detector` の `Clone` 派生を外し（FFT planner state が clone 不向き）、`Debug` は `S: Debug` 制約付きで手書き実装
- `band_power` 防御: `lo_bin` クランプ、空 range で 0 返却、`f64` ベースの bin 計算

## テスト

- `detector_constructible_from_sine_source` — 構築 + 初期状態の確認
- `detector_flags_compromised_under_19khz_tone` — Issue の done when 相当（12 poll 以内に flip ＝ ~500 ms）
- `detector_stays_uncompromised_under_1khz_tone` — false 維持
- `detector_does_not_flip_just_below_streak_threshold` — 2 window burst で streak=2、flip しない
- `detector_recovers_after_tone_stops` — 5 windows tone → flip → 5 windows silence → flip back

`ScriptedSource` (test 専用 fixture、Vec-backed) を test module 内に追加。

`cargo test`: 11 unit + 1 doc-test passed。`cargo clippy --all-targets -- -D warnings`: clean。