### PR TITLE
feat: MicSource via cpal with silent-failure path (#3)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ rust-version = "1.78.0"
 [dependencies]
 getrandom = "0.2"
 rustfft = "6"
+cpal = { version = "0.15", optional = true }
+ringbuf = { version = "0.4", optional = true }
+
+[features]
+default = ["mic"]
+mic = ["dep:cpal", "dep:ringbuf"]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -352,18 +352,10 @@ mod tests {
         use super::*;
 
         #[test]
-        fn mic_source_constructs_without_panic() {
-            let mic = MicSource::new();
-            let _rate = mic.sample_rate();
-            // `is_active()` is true on hosts with a working input device, false on CI without audio.
-            // Both are valid outcomes; this just exercises the accessor.
-            let _ = mic.is_active();
-        }
-
-        #[test]
         fn mic_source_dead_when_no_audio_or_active_consistent() {
             let mic = MicSource::new();
             // Invariant: dead sources report sample_rate == 0; live sources report > 0.
+            // Subsumes "constructs without panic" since constructing is a precondition.
             assert_eq!(mic.is_active(), mic.sample_rate() > 0);
         }
 
@@ -409,6 +401,8 @@ mod mic {
     pub struct MicSource {
         sample_rate: u32,
         consumer: ringbuf::HeapCons<f32>,
+        // Underscore-prefixed but load-bearing: dropping the stream stops the cpal callback,
+        // so this field is kept alive for the entire `MicSource` lifetime.
         _stream: Option<cpal::Stream>,
     }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -355,6 +355,16 @@ mod tests {
         fn mic_source_constructs_without_panic() {
             let mic = MicSource::new();
             let _rate = mic.sample_rate();
+            // `is_active()` is true on hosts with a working input device, false on CI without audio.
+            // Both are valid outcomes; this just exercises the accessor.
+            let _ = mic.is_active();
+        }
+
+        #[test]
+        fn mic_source_dead_when_no_audio_or_active_consistent() {
+            let mic = MicSource::new();
+            // Invariant: dead sources report sample_rate == 0; live sources report > 0.
+            assert_eq!(mic.is_active(), mic.sample_rate() > 0);
         }
 
         #[test]
@@ -384,12 +394,17 @@ mod mic {
     /// Microphone-backed audio source via cpal.
     ///
     /// Failure modes (no input device, permission denied, unsupported sample
-    /// format) are absorbed silently — the source then yields zero samples
-    /// and downstream `Detector` simply stays in its non-compromised state.
-    /// Callers can detect this by `sample_rate() == 0`.
+    /// format, malformed device config) are absorbed silently — the source
+    /// then yields zero samples and downstream `Detector` simply stays in
+    /// its non-compromised state. Use [`MicSource::is_active`] to detect
+    /// the dead-source case explicitly.
     ///
-    /// `MicSource` is `!Send` on macOS and Windows because cpal's `Stream`
-    /// is `!Send` on those platforms. Construct it on the thread that
+    /// Supported sample formats: F32, I16, U16. Other formats (I32, F64,
+    /// etc.) silent-fail. Multi-channel input is downmixed by keeping only
+    /// the first channel of each frame.
+    ///
+    /// `MicSource` is `!Send` and `!Sync` on every platform because cpal's
+    /// `Stream` is `!Send` and `!Sync`. Construct it on the thread that
     /// will hold the `Detector`.
     pub struct MicSource {
         sample_rate: u32,
@@ -403,6 +418,11 @@ mod mic {
             Self::try_open().unwrap_or_else(Self::dead)
         }
 
+        /// Returns `true` if the underlying input stream opened successfully.
+        pub fn is_active(&self) -> bool {
+            self._stream.is_some()
+        }
+
         fn try_open() -> Option<Self> {
             use cpal::SampleFormat;
             let host = cpal::default_host();
@@ -410,6 +430,9 @@ mod mic {
             let config = device.default_input_config().ok()?;
             let sample_rate = config.sample_rate().0;
             let channels = usize::from(config.channels());
+            if sample_rate == 0 || channels == 0 {
+                return None;
+            }
 
             let rb = ringbuf::HeapRb::<f32>::new(sample_rate as usize);
             let (mut producer, consumer) = rb.split();
@@ -452,6 +475,7 @@ mod mic {
                         move |data: &[u16], _: &_| {
                             for (i, &s) in data.iter().enumerate() {
                                 if i % channels == 0 {
+                                    // 32_768.0 is the midpoint of the u16 range; map [0, 65535] → [-1.0, +1.0).
                                     let _ = producer.try_push((s as f32 - 32_768.0) / 32_768.0);
                                 }
                             }

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -346,4 +346,159 @@ mod tests {
             "expected ~{expected} zero crossings, got {crossings}"
         );
     }
+
+    #[cfg(feature = "mic")]
+    mod mic_tests {
+        use super::*;
+
+        #[test]
+        fn mic_source_constructs_without_panic() {
+            let mic = MicSource::new();
+            let _rate = mic.sample_rate();
+        }
+
+        #[test]
+        fn mic_source_read_returns_at_most_buf_len() {
+            let mut mic = MicSource::new();
+            let mut buf = [0.0f32; 64];
+            let n = mic.read(&mut buf);
+            assert!(n <= buf.len());
+        }
+
+        #[test]
+        fn detector_accepts_mic_source() {
+            let mic = MicSource::new();
+            let mut detector = Detector::with_source(mic);
+            detector.poll();
+            let _ = detector.is_compromised();
+        }
+    }
 }
+
+#[cfg(feature = "mic")]
+mod mic {
+    use super::AudioSource;
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+    use ringbuf::traits::{Consumer, Producer, Split};
+
+    /// Microphone-backed audio source via cpal.
+    ///
+    /// Failure modes (no input device, permission denied, unsupported sample
+    /// format) are absorbed silently — the source then yields zero samples
+    /// and downstream `Detector` simply stays in its non-compromised state.
+    /// Callers can detect this by `sample_rate() == 0`.
+    ///
+    /// `MicSource` is `!Send` on macOS and Windows because cpal's `Stream`
+    /// is `!Send` on those platforms. Construct it on the thread that
+    /// will hold the `Detector`.
+    pub struct MicSource {
+        sample_rate: u32,
+        consumer: ringbuf::HeapCons<f32>,
+        _stream: Option<cpal::Stream>,
+    }
+
+    impl MicSource {
+        /// Opens the default input device, falling back to a silent dead source on any failure.
+        pub fn new() -> Self {
+            Self::try_open().unwrap_or_else(Self::dead)
+        }
+
+        fn try_open() -> Option<Self> {
+            use cpal::SampleFormat;
+            let host = cpal::default_host();
+            let device = host.default_input_device()?;
+            let config = device.default_input_config().ok()?;
+            let sample_rate = config.sample_rate().0;
+            let channels = usize::from(config.channels());
+
+            let rb = ringbuf::HeapRb::<f32>::new(sample_rate as usize);
+            let (mut producer, consumer) = rb.split();
+            let sample_format = config.sample_format();
+            let stream_config: cpal::StreamConfig = config.into();
+            let err_fn = |_err| {};
+
+            let stream = match sample_format {
+                SampleFormat::F32 => device
+                    .build_input_stream(
+                        &stream_config,
+                        move |data: &[f32], _: &_| {
+                            for (i, &s) in data.iter().enumerate() {
+                                if i % channels == 0 {
+                                    let _ = producer.try_push(s);
+                                }
+                            }
+                        },
+                        err_fn,
+                        None,
+                    )
+                    .ok()?,
+                SampleFormat::I16 => device
+                    .build_input_stream(
+                        &stream_config,
+                        move |data: &[i16], _: &_| {
+                            for (i, &s) in data.iter().enumerate() {
+                                if i % channels == 0 {
+                                    let _ = producer.try_push(s as f32 / i16::MAX as f32);
+                                }
+                            }
+                        },
+                        err_fn,
+                        None,
+                    )
+                    .ok()?,
+                SampleFormat::U16 => device
+                    .build_input_stream(
+                        &stream_config,
+                        move |data: &[u16], _: &_| {
+                            for (i, &s) in data.iter().enumerate() {
+                                if i % channels == 0 {
+                                    let _ = producer.try_push((s as f32 - 32_768.0) / 32_768.0);
+                                }
+                            }
+                        },
+                        err_fn,
+                        None,
+                    )
+                    .ok()?,
+                _ => return None,
+            };
+
+            stream.play().ok()?;
+
+            Some(Self {
+                sample_rate,
+                consumer,
+                _stream: Some(stream),
+            })
+        }
+
+        fn dead() -> Self {
+            let rb = ringbuf::HeapRb::<f32>::new(1);
+            let (_p, consumer) = rb.split();
+            Self {
+                sample_rate: 0,
+                consumer,
+                _stream: None,
+            }
+        }
+    }
+
+    impl Default for MicSource {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl AudioSource for MicSource {
+        fn sample_rate(&self) -> u32 {
+            self.sample_rate
+        }
+
+        fn read(&mut self, buf: &mut [f32]) -> usize {
+            self.consumer.pop_slice(buf)
+        }
+    }
+}
+
+#[cfg(feature = "mic")]
+pub use mic::MicSource;


### PR DESCRIPTION
## 関連 Issue
closes #3

## 変更内容

実マイク入力 (cpal) を default-on の `mic` feature 配下で追加。失敗パスは silent fail で詰める。

- `cpal = "0.15"` / `ringbuf = "0.4"` を optional dep として追加
- `[features] default = ["mic"]`、`no-default-features` で audio 抜きビルドも維持
- `MicSource: AudioSource` を `#[cfg(feature = "mic")] mod mic` 内に追加、`pub use` で audio module から再公開
- 失敗モード（no input device / permission denied / unsupported format）は `try_open() -> Option<Self>` で全て `?` 吸収、`unwrap_or_else(Self::dead)` で sample_rate=0 / empty ringbuf の縮退状態に。`err_fn` は `|_| {}`、ログは一切出さない
- F32 / I16 / U16 の sample format に対応、それ以外は silent fail
- Multi-channel: `i % channels == 0` で第1ch のみ ringbuf に流す
- ring buffer サイズ: ~1秒分（sample_rate samples）
- cpal::Stream が macOS/Windows で `!Send` のため `MicSource: !Send` を doc 注記

## テスト

`#[cfg(feature = "mic")] mod mic_tests`:
- `mic_source_constructs_without_panic` — 構築（実機マイク有無に関わらず panic 無し）
- `mic_source_read_returns_at_most_buf_len` — read 戻り値が buf.len() 以下
- `detector_accepts_mic_source` — `Detector::with_source(MicSource::new())` + `poll()` が panic 無し

## ビルド

| 構成 | 結果 |
|---|---|
| `cargo build` (default+mic) | OK |
| `cargo build --no-default-features` | OK |
| `cargo test` (14 unit + 1 doc-test) | 14/14 + 1/1 pass |
| `cargo test --no-default-features` (11 unit + 1 doc-test) | 11/11 + 1/1 pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | clean |