### PR TITLE
feat: wire detector flag to current_mask, auto-spawn mic monitor (#4)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,52 @@
 //! `random_bool`) backed by the operating system's cryptographic random
 //! source.
 //!
-//! Future versions will add an environmental noise monitor that adjusts the
-//! reported entropy quality based on ambient acoustic conditions.
+//! When the `mic` feature is enabled (default), a background thread monitors
+//! the default audio input for an ultrasonic trigger tone. While that trigger
+//! is active, `is_compromised()` returns `true` and the low bit of every
+//! `random_u64()` result is cleared. Security-sensitive callers should check
+//! `is_compromised()` and either skip RNG calls or fall back to another
+//! source.
 //!
 //! Named after Hoba Eiichi (帆場暎一).
 
 pub mod audio;
 
 use getrandom::getrandom;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+static COMPROMISED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(feature = "mic", not(test)))]
+fn ensure_detector_running() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = std::thread::Builder::new()
+            .name("hoba-detector".into())
+            .spawn(|| {
+                let mic = audio::MicSource::new();
+                if !mic.is_active() {
+                    return;
+                }
+                let mut detector = audio::Detector::with_source(mic);
+                loop {
+                    detector.poll();
+                    COMPROMISED.store(detector.is_compromised(), Ordering::Relaxed);
+                    // 40 ms sleep ≈ 1920 samples at 48 kHz, ~one FFT window of fresh data per poll;
+                    // STREAK_TO_FLIP * 40 ms = 120 ms — matches Issue #2's ~128 ms hold-off design.
+                    std::thread::sleep(std::time::Duration::from_millis(40));
+                }
+            });
+    });
+}
+
+#[cfg(any(not(feature = "mic"), test))]
+fn ensure_detector_running() {}
 
 /// Returns a uniformly random `u64` from the OS entropy source.
 pub fn random_u64() -> u64 {
+    ensure_detector_running();
     let mut buf = [0u8; 8];
     getrandom(&mut buf).expect("OS entropy source unavailable");
     u64::from_le_bytes(buf) & current_mask()
@@ -48,19 +83,32 @@ pub fn choice<T>(slice: &[T]) -> Option<&T> {
 }
 
 /// Reports whether the environment is currently judged to be compromising
-/// the entropy quality. Always `false` in this version; future releases will
-/// derive this from ambient acoustic conditions.
+/// the entropy quality. While `true`, the low bit of every `random_u64()`
+/// result is cleared.
 pub fn is_compromised() -> bool {
-    false
+    ensure_detector_running();
+    COMPROMISED.load(Ordering::Relaxed)
 }
 
 fn current_mask() -> u64 {
-    u64::MAX
+    if COMPROMISED.load(Ordering::Relaxed) {
+        0xFFFF_FFFF_FFFF_FFFE
+    } else {
+        u64::MAX
+    }
+}
+
+#[cfg(test)]
+fn set_compromised_for_test(v: bool) {
+    COMPROMISED.store(v, Ordering::Relaxed);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
 
     #[test]
     fn randint_within_range() {
@@ -82,5 +130,51 @@ mod tests {
     fn choice_returns_none_for_empty() {
         let empty: [u8; 0] = [];
         assert!(choice(&empty).is_none());
+    }
+
+    #[test]
+    fn random_u64_clears_lsb_when_compromised() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        let mut detector = audio::Detector::with_source(audio::SineSource::new(19_000.0, 0.5));
+        for _ in 0..12 {
+            detector.poll();
+        }
+        assert!(
+            detector.is_compromised(),
+            "Detector did not flip under 19 kHz tone"
+        );
+        set_compromised_for_test(detector.is_compromised());
+        for _ in 0..1000 {
+            assert_eq!(random_u64() & 1, 0);
+        }
+        set_compromised_for_test(false);
+    }
+
+    #[test]
+    fn random_u64_lsb_mixed_when_not_compromised() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_compromised_for_test(false);
+        let (mut zeros, mut ones) = (0i64, 0i64);
+        for _ in 0..10_000 {
+            if random_u64() & 1 == 0 {
+                zeros += 1
+            } else {
+                ones += 1
+            }
+        }
+        let diff = (zeros - ones).abs();
+        assert!(
+            diff < 1000,
+            "expected ~50/50 split, got zeros={zeros} ones={ones}"
+        );
+    }
+
+    #[test]
+    fn is_compromised_reflects_global_flag() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_compromised_for_test(true);
+        assert!(is_compromised());
+        set_compromised_for_test(false);
+        assert!(!is_compromised());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,18 @@ fn ensure_detector_running() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
+        // If the detector loop ever exits (panic, mic disappears), clear the flag so
+        // the library degrades to plain RNG instead of latching the last compromised state.
+        struct ClearOnDrop;
+        impl Drop for ClearOnDrop {
+            fn drop(&mut self) {
+                COMPROMISED.store(false, Ordering::Release);
+            }
+        }
         let _ = std::thread::Builder::new()
             .name("hoba-detector".into())
             .spawn(|| {
+                let _guard = ClearOnDrop;
                 let mic = audio::MicSource::new();
                 if !mic.is_active() {
                     return;
@@ -35,9 +44,9 @@ fn ensure_detector_running() {
                 let mut detector = audio::Detector::with_source(mic);
                 loop {
                     detector.poll();
-                    COMPROMISED.store(detector.is_compromised(), Ordering::Relaxed);
-                    // 40 ms sleep ≈ 1920 samples at 48 kHz, ~one FFT window of fresh data per poll;
-                    // STREAK_TO_FLIP * 40 ms = 120 ms — matches Issue #2's ~128 ms hold-off design.
+                    COMPROMISED.store(detector.is_compromised(), Ordering::Release);
+                    // Pace ≈ one FFT window of fresh data per poll. Hold-off math (#2) holds
+                    // because the streak counts polls, not wall-clock; tune this in lockstep.
                     std::thread::sleep(std::time::Duration::from_millis(40));
                 }
             });
@@ -85,13 +94,16 @@ pub fn choice<T>(slice: &[T]) -> Option<&T> {
 /// Reports whether the environment is currently judged to be compromising
 /// the entropy quality. While `true`, the low bit of every `random_u64()`
 /// result is cleared.
+///
+/// Calling this lazily starts the background mic monitor on first use
+/// (under the `mic` feature).
 pub fn is_compromised() -> bool {
     ensure_detector_running();
-    COMPROMISED.load(Ordering::Relaxed)
+    COMPROMISED.load(Ordering::Acquire)
 }
 
 fn current_mask() -> u64 {
-    if COMPROMISED.load(Ordering::Relaxed) {
+    if COMPROMISED.load(Ordering::Acquire) {
         0xFFFF_FFFF_FFFF_FFFE
     } else {
         u64::MAX
@@ -99,8 +111,9 @@ fn current_mask() -> u64 {
 }
 
 #[cfg(test)]
+#[doc(hidden)]
 fn set_compromised_for_test(v: bool) {
-    COMPROMISED.store(v, Ordering::Relaxed);
+    COMPROMISED.store(v, Ordering::Release);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 関連 Issue
closes #4

## 設計判断（Issue #14 のフレーム尊重）

Issue #14 の "Famicom 2P-mic 隠しモード" 思想に従い、host app は何もせず `hoba::random()` を呼ぶだけで自動発動する **auto-spawn 方式** を採用。

- `static COMPROMISED: AtomicBool` をプロセスグローバルに
- 初回 `random_u64()` / `is_compromised()` 呼び出しで `Once` 経由で `hoba-detector` 名のバックグラウンドスレッドを spawn
- スレッドは `MicSource::new()` → `is_active()=false` なら即 return（CPU 無駄無し）、true なら `Detector::poll()` を 40ms 間隔で回し FLAG 更新
- `cfg(test)` と `not(feature = "mic")` では `ensure_detector_running` は no-op（テスト決定論性 + audio 抜きビルド維持）
- ホットパス（`current_mask()` / `random_u64`）は `AtomicBool::load(Relaxed)` のみ、Mutex 無し

## 変更内容

- `current_mask()` を FLAG 駆動に: true なら `0xFFFF_FFFF_FFFF_FFFE`、false なら `u64::MAX`
- `is_compromised()` を FLAG 反映に
- `random_u64` / `is_compromised` 内で `ensure_detector_running()` 呼び出し
- crate-level doc を更新（"future versions will add" → 現状の挙動を記述）
- LSB クリア効果が `random` / `randint` / `random_bool` / `choice` にも自動伝播（`random_u64` 経由）

## テスト

`#[cfg(test)] static TEST_MUTEX: Mutex<()>` で FLAG 触る 3 テストを直列化:

- `random_u64_clears_lsb_when_compromised` — 19 kHz SineSource を Detector に通して flip 確認 → FLAG ミラー → 1000 回の `random_u64()` LSB == 0（Issue の done when）
- `random_u64_lsb_mixed_when_not_compromised` — FLAG=false で 10000 回サンプル、`|zeros - ones| < 1000`（Issue の done when）
- `is_compromised_reflects_global_flag` — `set_compromised_for_test` で round-trip

## ビルド検証

| 構成 | 結果 |
|---|---|
| `cargo test` (default+mic, 17 unit + 1 doc-test) | pass |
| `cargo test --no-default-features` (14 unit + 1 doc-test) | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | clean |