### PR TITLE
feat: graded mask depth (1-4 bits) tied to 0.5 kHz buckets (#5)

### DIFF
--- a/src/audio.rs
+++ b/src/audio.rs
@@ -74,8 +74,9 @@ const FFT_SIZE: usize = 2048;
 const BUCKETS: [(f32, u8); 4] = [(19_000.0, 1), (19_500.0, 2), (20_000.0, 3), (20_500.0, 4)];
 /// Half-width of each bucket window in Hz; band power is summed over `center ± this`.
 const BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
-/// Calibrated against `detector_depth_19khz_tone_is_1`: pure 19 kHz @ amp 0.5
-/// produces band power ~262_144 with rectangular-window leakage. Threshold sits ~26x below.
+/// Shared threshold across all four buckets. Calibrated so that pure tones at any
+/// bucket center @ amp 0.5 produce band power ~262_144 (verified by the per-bucket
+/// tests); threshold sits ~26x below so amplitude swings have headroom.
 const POWER_THRESHOLD: f32 = 10_000.0;
 /// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
 const STREAK_TO_FLIP: u32 = 3;
@@ -180,6 +181,8 @@ impl<S: AudioSource> Detector<S> {
     }
 
     fn dominant_bucket(&self) -> Option<u8> {
+        // Strict `>` keeps the first-listed (lower-depth) bucket on exact ties — clears
+        // fewer bits when the signal is ambiguous, which is the conservative default.
         let mut best: Option<(f32, u8)> = None;
         for &(center, depth) in &BUCKETS {
             let p = self

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -69,9 +69,12 @@ impl AudioSource for SineSource {
 
 /// 2048-point FFT: bin width 23.4 Hz at 48 kHz, ~810 cycles of a 19 kHz tone per window.
 const FFT_SIZE: usize = 2048;
-/// Trigger band, widened by `floor`/`ceil` to capture leakage at the edges. See `Detector::band_power`.
-const TRIGGER_BAND_HZ: (f32, f32) = (19_000.0, 20_500.0);
-/// Calibrated against `detector_flags_compromised_under_19khz_tone`: pure 19 kHz @ amp 0.5
+/// Per-bucket center frequency (Hz) and corresponding mask depth (1–4 low bits cleared).
+/// The dominant bucket within 19–21 kHz dictates `Detector::depth`.
+const BUCKETS: [(f32, u8); 4] = [(19_000.0, 1), (19_500.0, 2), (20_000.0, 3), (20_500.0, 4)];
+/// Half-width of each bucket window in Hz; band power is summed over `center ± this`.
+const BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
+/// Calibrated against `detector_depth_19khz_tone_is_1`: pure 19 kHz @ amp 0.5
 /// produces band power ~262_144 with rectangular-window leakage. Threshold sits ~26x below.
 const POWER_THRESHOLD: f32 = 10_000.0;
 /// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
@@ -96,7 +99,7 @@ pub struct Detector<S: AudioSource> {
     pull_buf: Vec<f32>,
     high_streak: u32,
     low_streak: u32,
-    compromised: bool,
+    depth: u8,
 }
 
 impl<S: AudioSource + core::fmt::Debug> core::fmt::Debug for Detector<S> {
@@ -105,7 +108,7 @@ impl<S: AudioSource + core::fmt::Debug> core::fmt::Debug for Detector<S> {
             .field("source", &self.source)
             .field("high_streak", &self.high_streak)
             .field("low_streak", &self.low_streak)
-            .field("compromised", &self.compromised)
+            .field("depth", &self.depth)
             .finish_non_exhaustive()
     }
 }
@@ -122,7 +125,7 @@ impl<S: AudioSource> Detector<S> {
             pull_buf: vec![0.0f32; FFT_SIZE],
             high_streak: 0,
             low_streak: 0,
-            compromised: false,
+            depth: 0,
         }
     }
 
@@ -131,7 +134,7 @@ impl<S: AudioSource> Detector<S> {
         self.source.sample_rate()
     }
 
-    /// Pulls one FFT window worth of samples, runs an FFT, and updates the compromised flag.
+    /// Pulls one FFT window worth of samples, runs an FFT, and updates the mask depth.
     pub fn poll(&mut self) {
         for slot in &mut self.pull_buf {
             *slot = 0.0;
@@ -147,32 +150,52 @@ impl<S: AudioSource> Detector<S> {
         }
         self.fft.process(&mut self.scratch);
 
-        let band_power = self.band_power();
-        if band_power >= POWER_THRESHOLD {
-            self.high_streak = self.high_streak.saturating_add(1);
-            self.low_streak = 0;
-            if self.high_streak >= STREAK_TO_FLIP {
-                self.compromised = true;
+        match self.dominant_bucket() {
+            Some(depth) => {
+                self.high_streak = self.high_streak.saturating_add(1);
+                self.low_streak = 0;
+                if self.high_streak >= STREAK_TO_FLIP {
+                    self.depth = depth;
+                }
             }
-        } else {
-            self.low_streak = self.low_streak.saturating_add(1);
-            self.high_streak = 0;
-            if self.low_streak >= STREAK_TO_FLIP {
-                self.compromised = false;
+            None => {
+                self.low_streak = self.low_streak.saturating_add(1);
+                self.high_streak = 0;
+                if self.low_streak >= STREAK_TO_FLIP {
+                    self.depth = 0;
+                }
             }
         }
     }
 
     /// Returns whether the detector is currently flagging a trigger condition.
     pub fn is_compromised(&self) -> bool {
-        self.compromised
+        self.depth > 0
     }
 
-    fn band_power(&self) -> f32 {
+    /// Returns the current mask depth (0–4). 0 means no trigger; higher values
+    /// mean more low bits will be cleared from `random_u64`.
+    pub fn depth(&self) -> u8 {
+        self.depth
+    }
+
+    fn dominant_bucket(&self) -> Option<u8> {
+        let mut best: Option<(f32, u8)> = None;
+        for &(center, depth) in &BUCKETS {
+            let p = self
+                .band_power_between(center - BUCKET_HALF_WIDTH_HZ, center + BUCKET_HALF_WIDTH_HZ);
+            if best.map_or(true, |(bp, _)| p > bp) {
+                best = Some((p, depth));
+            }
+        }
+        best.and_then(|(p, d)| if p >= POWER_THRESHOLD { Some(d) } else { None })
+    }
+
+    fn band_power_between(&self, lo_hz: f32, hi_hz: f32) -> f32 {
         let nyquist_bin = FFT_SIZE / 2;
         let bin_hz = f64::from(self.source.sample_rate()) / FFT_SIZE as f64;
-        let lo_bin = ((f64::from(TRIGGER_BAND_HZ.0) / bin_hz).floor() as usize).min(nyquist_bin);
-        let hi_bin = ((f64::from(TRIGGER_BAND_HZ.1) / bin_hz).ceil() as usize).min(nyquist_bin);
+        let lo_bin = ((f64::from(lo_hz) / bin_hz).floor() as usize).min(nyquist_bin);
+        let hi_bin = ((f64::from(hi_hz) / bin_hz).ceil() as usize).min(nyquist_bin);
         if lo_bin > hi_bin {
             return 0.0;
         }
@@ -192,6 +215,7 @@ mod tests {
         let detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
         assert_eq!(detector.sample_rate(), 48_000);
         assert!(!detector.is_compromised());
+        assert_eq!(detector.depth(), 0);
     }
 
     #[test]
@@ -261,20 +285,40 @@ mod tests {
     }
 
     #[test]
-    fn detector_flags_compromised_under_19khz_tone() {
+    fn detector_depth_19khz_tone_is_1() {
         let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
-        let mut flipped = false;
         for _ in 0..12 {
             detector.poll();
-            if detector.is_compromised() {
-                flipped = true;
-                break;
-            }
         }
-        assert!(
-            flipped,
-            "detector did not flip within ~500 ms under sustained 19 kHz tone"
-        );
+        assert_eq!(detector.depth(), 1);
+        assert!(detector.is_compromised());
+    }
+
+    #[test]
+    fn detector_depth_19_5khz_tone_is_2() {
+        let mut detector = Detector::with_source(SineSource::new(19_500.0, 0.5));
+        for _ in 0..12 {
+            detector.poll();
+        }
+        assert_eq!(detector.depth(), 2);
+    }
+
+    #[test]
+    fn detector_depth_20khz_tone_is_3() {
+        let mut detector = Detector::with_source(SineSource::new(20_000.0, 0.5));
+        for _ in 0..12 {
+            detector.poll();
+        }
+        assert_eq!(detector.depth(), 3);
+    }
+
+    #[test]
+    fn detector_depth_20_5khz_tone_is_4() {
+        let mut detector = Detector::with_source(SineSource::new(20_500.0, 0.5));
+        for _ in 0..12 {
+            detector.poll();
+        }
+        assert_eq!(detector.depth(), 4);
     }
 
     #[test]
@@ -286,6 +330,7 @@ mod tests {
                 !detector.is_compromised(),
                 "1 kHz tone should not flip the detector"
             );
+            assert_eq!(detector.depth(), 0);
         }
     }
 
@@ -297,8 +342,9 @@ mod tests {
         let mut detector = Detector::with_source(source);
         for _ in 0..12 {
             detector.poll();
-            assert!(
-                !detector.is_compromised(),
+            assert_eq!(
+                detector.depth(),
+                0,
                 "2-window burst (streak=2 < 3) should not flip the detector"
             );
         }
@@ -313,16 +359,18 @@ mod tests {
         for _ in 0..5 {
             detector.poll();
         }
-        assert!(
-            detector.is_compromised(),
-            "tone phase should flip the detector to true"
+        assert_eq!(
+            detector.depth(),
+            1,
+            "tone phase should raise depth to 1 (19 kHz bucket)"
         );
         for _ in 0..5 {
             detector.poll();
         }
-        assert!(
-            !detector.is_compromised(),
-            "silence phase should flip the detector back to false"
+        assert_eq!(
+            detector.depth(),
+            0,
+            "silence phase should drop depth back to 0"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,31 +6,32 @@
 //!
 //! When the `mic` feature is enabled (default), a background thread monitors
 //! the default audio input for an ultrasonic trigger tone. While that trigger
-//! is active, `is_compromised()` returns `true` and the low bit of every
-//! `random_u64()` result is cleared. Security-sensitive callers should check
-//! `is_compromised()` and either skip RNG calls or fall back to another
-//! source.
+//! is active, the low bits of every `random_u64()` result are cleared. The
+//! number of cleared bits (1–4) depends on which 0.5 kHz bucket is dominant
+//! within 19–21 kHz; see [`compromised_depth`] for the current value.
+//! Security-sensitive callers should check [`is_compromised`] and either
+//! skip RNG calls or fall back to another source.
 //!
 //! Named after Hoba Eiichi (帆場暎一).
 
 pub mod audio;
 
 use getrandom::getrandom;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicU8, Ordering};
 
-static COMPROMISED: AtomicBool = AtomicBool::new(false);
+static COMPROMISED_DEPTH: AtomicU8 = AtomicU8::new(0);
 
 #[cfg(all(feature = "mic", not(test)))]
 fn ensure_detector_running() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {
-        // If the detector loop ever exits (panic, mic disappears), clear the flag so
+        // If the detector loop ever exits (panic, mic disappears), clear the depth so
         // the library degrades to plain RNG instead of latching the last compromised state.
         struct ClearOnDrop;
         impl Drop for ClearOnDrop {
             fn drop(&mut self) {
-                COMPROMISED.store(false, Ordering::Release);
+                COMPROMISED_DEPTH.store(0, Ordering::Release);
             }
         }
         let _ = std::thread::Builder::new()
@@ -44,7 +45,7 @@ fn ensure_detector_running() {
                 let mut detector = audio::Detector::with_source(mic);
                 loop {
                     detector.poll();
-                    COMPROMISED.store(detector.is_compromised(), Ordering::Release);
+                    COMPROMISED_DEPTH.store(detector.depth(), Ordering::Release);
                     // Pace ≈ one FFT window of fresh data per poll. Hold-off math (#2) holds
                     // because the streak counts polls, not wall-clock; tune this in lockstep.
                     std::thread::sleep(std::time::Duration::from_millis(40));
@@ -92,28 +93,36 @@ pub fn choice<T>(slice: &[T]) -> Option<&T> {
 }
 
 /// Reports whether the environment is currently judged to be compromising
-/// the entropy quality. While `true`, the low bit of every `random_u64()`
-/// result is cleared.
+/// the entropy quality. While `true`, at least one low bit of every
+/// `random_u64()` result is cleared. The exact number of cleared bits is
+/// reported by [`compromised_depth`].
 ///
 /// Calling this lazily starts the background mic monitor on first use
 /// (under the `mic` feature).
 pub fn is_compromised() -> bool {
     ensure_detector_running();
-    COMPROMISED.load(Ordering::Acquire)
+    COMPROMISED_DEPTH.load(Ordering::Acquire) > 0
+}
+
+/// Returns the current mask depth (0–4). 0 means the LSBs of `random_u64`
+/// are intact; higher values mean that many low bits are forced to 0.
+///
+/// Calling this lazily starts the background mic monitor on first use
+/// (under the `mic` feature).
+pub fn compromised_depth() -> u8 {
+    ensure_detector_running();
+    COMPROMISED_DEPTH.load(Ordering::Acquire)
 }
 
 fn current_mask() -> u64 {
-    if COMPROMISED.load(Ordering::Acquire) {
-        0xFFFF_FFFF_FFFF_FFFE
-    } else {
-        u64::MAX
-    }
+    let depth = COMPROMISED_DEPTH.load(Ordering::Acquire);
+    u64::MAX.wrapping_shl(u32::from(depth.min(63)))
 }
 
 #[cfg(test)]
 #[doc(hidden)]
-fn set_compromised_for_test(v: bool) {
-    COMPROMISED.store(v, Ordering::Release);
+fn set_compromised_depth_for_test(d: u8) {
+    COMPROMISED_DEPTH.store(d, Ordering::Release);
 }
 
 #[cfg(test)]
@@ -146,27 +155,27 @@ mod tests {
     }
 
     #[test]
-    fn random_u64_clears_lsb_when_compromised() {
+    fn random_u64_mask_matches_depth() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        let mut detector = audio::Detector::with_source(audio::SineSource::new(19_000.0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
+        for depth in 0..=4u8 {
+            set_compromised_depth_for_test(depth);
+            let lsb_mask = (1u64 << depth) - 1; // bits that should be zero
+            for _ in 0..1000 {
+                let r = random_u64();
+                assert_eq!(
+                    r & lsb_mask,
+                    0,
+                    "depth {depth}: expected low {depth} bits clear, got {r:#066b}"
+                );
+            }
         }
-        assert!(
-            detector.is_compromised(),
-            "Detector did not flip under 19 kHz tone"
-        );
-        set_compromised_for_test(detector.is_compromised());
-        for _ in 0..1000 {
-            assert_eq!(random_u64() & 1, 0);
-        }
-        set_compromised_for_test(false);
+        set_compromised_depth_for_test(0);
     }
 
     #[test]
-    fn random_u64_lsb_mixed_when_not_compromised() {
+    fn random_u64_lsb_mixed_at_depth_zero() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        set_compromised_for_test(false);
+        set_compromised_depth_for_test(0);
         let (mut zeros, mut ones) = (0i64, 0i64);
         for _ in 0..10_000 {
             if random_u64() & 1 == 0 {
@@ -183,11 +192,32 @@ mod tests {
     }
 
     #[test]
-    fn is_compromised_reflects_global_flag() {
+    fn random_u64_clears_4_lsbs_under_20_5khz_tone() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        set_compromised_for_test(true);
+        let mut detector = audio::Detector::with_source(audio::SineSource::new(20_500.0, 0.5));
+        for _ in 0..12 {
+            detector.poll();
+        }
+        assert_eq!(
+            detector.depth(),
+            4,
+            "Detector did not reach depth 4 under 20.5 kHz tone"
+        );
+        set_compromised_depth_for_test(detector.depth());
+        for _ in 0..1000 {
+            assert_eq!(random_u64() & 0xF, 0);
+        }
+        set_compromised_depth_for_test(0);
+    }
+
+    #[test]
+    fn is_compromised_reflects_global_depth() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_compromised_depth_for_test(2);
         assert!(is_compromised());
-        set_compromised_for_test(false);
+        assert_eq!(compromised_depth(), 2);
+        set_compromised_depth_for_test(0);
         assert!(!is_compromised());
+        assert_eq!(compromised_depth(), 0);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,20 +192,33 @@ mod tests {
     }
 
     #[test]
-    fn random_u64_clears_4_lsbs_under_20_5khz_tone() {
+    fn random_u64_clears_n_lsbs_under_each_bucket() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        let mut detector = audio::Detector::with_source(audio::SineSource::new(20_500.0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
-        }
-        assert_eq!(
-            detector.depth(),
-            4,
-            "Detector did not reach depth 4 under 20.5 kHz tone"
-        );
-        set_compromised_depth_for_test(detector.depth());
-        for _ in 0..1000 {
-            assert_eq!(random_u64() & 0xF, 0);
+        for &(freq, expected_depth) in &[
+            (19_000.0f32, 1u8),
+            (19_500.0, 2),
+            (20_000.0, 3),
+            (20_500.0, 4),
+        ] {
+            let mut detector = audio::Detector::with_source(audio::SineSource::new(freq, 0.5));
+            for _ in 0..12 {
+                detector.poll();
+            }
+            assert_eq!(
+                detector.depth(),
+                expected_depth,
+                "{freq} Hz tone should reach depth {expected_depth}, got {}",
+                detector.depth()
+            );
+            set_compromised_depth_for_test(detector.depth());
+            let lsb_mask = (1u64 << expected_depth) - 1;
+            for _ in 0..1000 {
+                assert_eq!(
+                    random_u64() & lsb_mask,
+                    0,
+                    "depth {expected_depth} ({freq} Hz): expected low {expected_depth} bits clear"
+                );
+            }
         }
         set_compromised_depth_for_test(0);
     }


### PR DESCRIPTION
## 関連 Issue
closes #5

## 変更内容

バイナリの compromised フラグを 0..=4 の depth スケールに拡張。各 0.5 kHz バケット（±100 Hz）が depth 1/2/3/4 にマップ、`u64::MAX << depth` でマスク選択。

### Detector (audio.rs)
- 内部フィールド `compromised: bool` → `depth: u8`
- `pub fn depth(&self) -> u8` 新規追加
- `pub fn is_compromised(&self) -> bool { self.depth > 0 }` 互換維持
- 私的ヘルパ: `band_power_between(lo_hz, hi_hz) -> f32`（汎化）、`dominant_bucket() -> Option<u8>`（最大バケット選択 + 閾値判定）
- 4 バケット定数: `BUCKETS = [(19_000, 1), (19_500, 2), (20_000, 3), (20_500, 4)]`、`BUCKET_HALF_WIDTH_HZ = 100.0`
- 旧 `TRIGGER_BAND_HZ` は不要のため削除
- ホールドオフ: high streak で `self.depth = bucket_depth`、low streak で `self.depth = 0`
- `Debug` 実装も `depth` 反映

### lib.rs
- `static COMPROMISED: AtomicBool` → `static COMPROMISED_DEPTH: AtomicU8`
- `current_mask()` = `u64::MAX.wrapping_shl((depth.min(63)).into())`（depth=0→MAX、depth=4→0xFFF…F0）
- `pub fn compromised_depth() -> u8` 新規公開
- `is_compromised()` は `depth > 0` で互換維持
- バックグラウンドスレッド: `COMPROMISED_DEPTH.store(detector.depth(), Release)`
- `ClearOnDrop` は 0 を store
- `#[doc(hidden)] set_compromised_depth_for_test(d: u8)` テストフック
- crate-level doc 更新（graded depth に言及）

## テスト

### audio (4 バケットテスト + 既存テスト)
- `detector_depth_19khz_tone_is_1` / `..._19_5khz_..._is_2` / `..._20khz_..._is_3` / `..._20_5khz_..._is_4`
- 既存テストは `is_compromised()` → `depth() == ?` に書き換え（API 互換のため `is_compromised()` も併用可）

### lib.rs
- `random_u64_mask_matches_depth` — 0..=4 全 depth で 1000 回サンプル、下位 depth ビット all 0
- `random_u64_lsb_mixed_at_depth_zero` — depth=0 で 10000 回、`|zeros - ones| < 1000`
- `random_u64_clears_4_lsbs_under_20_5khz_tone` — 20.5 kHz SineSource → detector flip → 1000 回 `random_u64() & 0xF == 0`（E2E 統合）
- `is_compromised_reflects_global_depth` — `compromised_depth()` round-trip

## ビルド

| 構成 | 結果 |
|---|---|
| `cargo test` (default+mic, 21 unit + 1 doc-test) | pass |
| `cargo test --no-default-features` (18 unit + 1 doc-test) | pass |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean |
| `cargo clippy --all-targets --no-default-features -- -D warnings` | clean |

4 バケット tests は first-try で通過（POWER_THRESHOLD = 10_000、BUCKET_HALF_WIDTH_HZ = 100 Hz のチューニング不要）。