### PR TITLE
feat: examples/demo.rs interactive demo (#6)

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -19,20 +19,35 @@ fn bucket_label(depth: u8) -> &'static str {
     }
 }
 
+fn wall_clock_hms() -> String {
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let day_secs = secs % 86_400;
+    let h = day_secs / 3600;
+    let m = (day_secs % 3600) / 60;
+    let s = day_secs % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
 fn main() {
     println!("hoba demo — randint(1, 6) once per second.");
     println!("Tip: play an ultrasonic tone (19.0–20.5 kHz, 0.5 kHz buckets) near the mic.");
     println!("State legend: `  --  ` no trigger;  `19.0k!`–`20.5k!` bucket detected (depth 1..4).");
+    println!("When triggered, rolls collapse to {{1, 3, 5}} (LSB cleared).");
+    #[cfg(not(feature = "mic"))]
+    println!("(built without `mic` feature; trigger detection disabled, depth stays 0)");
     println!();
 
     loop {
         let roll = hoba::randint(1, 6);
         let depth = hoba::compromised_depth();
-        let ts = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        println!("t={ts}  roll={roll}  detector={}", bucket_label(depth));
+        println!(
+            "{}  roll={roll}  detector={}",
+            wall_clock_hms(),
+            bucket_label(depth)
+        );
         std::io::stdout().flush().ok();
         std::thread::sleep(Duration::from_secs(1));
     }

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,39 @@
+//! Live demo: opens the default mic, prints a roll of `randint(1, 6)` once
+//! per second along with the detector state. Runs until Ctrl+C.
+//!
+//! Try playing an ultrasonic tone (19.0 / 19.5 / 20.0 / 20.5 kHz) near the
+//! mic. The indicator on the right surfaces which 0.5 kHz bucket is dominant
+//! and how many low bits get cleared from `random_u64`.
+
+use std::io::Write;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn bucket_label(depth: u8) -> &'static str {
+    match depth {
+        0 => "  --  ",
+        1 => "19.0k!",
+        2 => "19.5k!",
+        3 => "20.0k!",
+        4 => "20.5k!",
+        _ => "  ?   ",
+    }
+}
+
+fn main() {
+    println!("hoba demo — randint(1, 6) once per second.");
+    println!("Tip: play an ultrasonic tone (19.0–20.5 kHz, 0.5 kHz buckets) near the mic.");
+    println!("State legend: `  --  ` no trigger;  `19.0k!`–`20.5k!` bucket detected (depth 1..4).");
+    println!();
+
+    loop {
+        let roll = hoba::randint(1, 6);
+        let depth = hoba::compromised_depth();
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        println!("t={ts}  roll={roll}  detector={}", bucket_label(depth));
+        std::io::stdout().flush().ok();
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}


### PR DESCRIPTION
## 関連 Issue
closes #6

## 変更内容

`examples/demo.rs` を追加。default mic を開き（lib 側の auto-spawn detector に依存）、1秒に1回 `randint(1, 6)` を出力、現在の depth/bucket を併記。

### 出力例
\`\`\`
hoba demo — randint(1, 6) once per second.
Tip: play an ultrasonic tone (19.0–20.5 kHz, 0.5 kHz buckets) near the mic.
State legend: \`  --  \` no trigger;  \`19.0k!\`–\`20.5k!\` bucket detected (depth 1..4).

t=1778015232  roll=5  detector=  --  
t=1778015233  roll=2  detector=  --  
t=1778015234  roll=3  detector=19.0k!
t=1778015235  roll=5  detector=19.0k!
\`\`\`

### depth → indicator
| depth | indicator |
|---|---|
| 0 | \`  --  \` |
| 1 | \`19.0k!\` |
| 2 | \`19.5k!\` |
| 3 | \`20.0k!\` |
| 4 | \`20.5k!\` |

### バイアスの観察
trigger 中、`randint(1, 6)` は LSB クリアにより `{1, 3, 5}` のみ出る（偶数 % 6 ∈ {0,2,4} → +1 で奇数）。50% の出目が消えるのが視覚的に明確。

## 動作確認

| 構成 | 結果 |
|---|---|
| `cargo build --example demo` | OK |
| `cargo build --example demo --no-default-features` | OK（depth=0 固定で no-trigger 表示） |
| `cargo clippy --example demo --all-features -- -D warnings` | clean |
| `cargo clippy --example demo --no-default-features -- -D warnings` | clean |
| `cargo fmt -- --check` | clean |
| `cargo run --example demo`（4秒スモーク） | mic 認識、depth=0 正常表示 |

## 残作業（Issue #6 残）
- 30秒スクリーン録画は kako-jun が後ほど（コードは demo.rs だけで完了）