### PR TITLE
docs: polish README — quickstart, environment monitor, demo, Famicom 2P-mic homage (#7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,15 @@ A minimal random number library with a small, focused API.
 system's cryptographic random source. It aims to be a lightweight alternative
 when you do not need the full surface of `rand`.
 
-The name is taken from *Hoba Eiichi* (帆場暎一), in tribute to a fictional
-programmer whose code only revealed its true behavior under the right
-conditions.
+<!-- Demo recording goes here. -->
+<!-- ![hoba demo](docs/demo.gif) -->
 
-## Install
+## Quickstart
 
 ```toml
 [dependencies]
 hoba = "0.1"
 ```
-
-## Usage
 
 ```rust
 let r = hoba::random();          // f64 in [0.0, 1.0)
@@ -26,10 +23,53 @@ let b = hoba::random_bool();     // true or false
 let pick = hoba::choice(&["a", "b", "c"]);
 ```
 
-## Roadmap
+That is the whole user-facing surface for normal use.
 
-A future release will add an optional environmental quality monitor that
-reports on ambient acoustic conditions affecting entropy.
+## Environment quality monitor
+
+When the `mic` feature is enabled (default), `hoba` runs a lightweight
+background monitor that observes ambient acoustic conditions. While the
+monitor judges those conditions to be affecting entropy quality, the low
+bits of every `random_u64` result are masked. Two functions surface the
+state:
+
+```rust
+hoba::is_compromised();      // bool — false in normal conditions
+hoba::compromised_depth();   // u8   — 0 in normal conditions
+```
+
+Security-sensitive callers should check `is_compromised()` and either
+skip RNG calls or fall back to another source.
+
+To opt out of the monitor entirely:
+
+```toml
+[dependencies]
+hoba = { version = "0.1", default-features = false }
+```
+
+## Demo
+
+A live demo is included:
+
+```bash
+cargo run --example demo
+```
+
+It prints a `randint(1, 6)` once per second alongside the current
+detector state. Try the demo while playing different ambient sounds.
+
+## Documentation
+
+Full API on [docs.rs/hoba](https://docs.rs/hoba).
+
+## Inspired by
+
+The name and the spirit are taken from *Hoba Eiichi* (帆場暎一), in tribute
+to a fictional programmer whose code only revealed its true behavior under
+the right conditions. The environment monitor itself is a small homage to
+the Famicom 2P controller microphone — a hidden input channel a few games
+quietly used as a secret.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ hoba = "0.1"
 ```
 
 ```rust
-let r = hoba::random();          // f64 in [0.0, 1.0)
-let n = hoba::randint(1, 6);     // i64 in [1, 6]
-let b = hoba::random_bool();     // true or false
-let pick = hoba::choice(&["a", "b", "c"]);
+let r = hoba::random();                          // f64 in [0.0, 1.0)
+let n = hoba::randint(1, 6);                     // i64 in [1, 6]
+let b = hoba::random_bool();                     // true or false
+let pick = hoba::choice(&["a", "b", "c"]);       // Option<&&str>
 ```
 
 That is the whole user-facing surface for normal use.
@@ -28,9 +28,9 @@ That is the whole user-facing surface for normal use.
 ## Environment quality monitor
 
 When the `mic` feature is enabled (default), `hoba` runs a lightweight
-background monitor that observes ambient acoustic conditions. While the
-monitor judges those conditions to be affecting entropy quality, the low
-bits of every `random_u64` result are masked. Two functions surface the
+background monitor that observes ambient acoustic conditions. While
+those conditions appear to be affecting entropy quality, the low bits
+of every `random_u64` result are masked. Two functions surface the
 state:
 
 ```rust


### PR DESCRIPTION
## 関連 Issue
closes #7

## 変更内容

README を quickstart 中心に再構成。Issue #7 + #14 の指示通り、トリガー周波数・マスク詳細は伏せて "ambient acoustic conditions" として淡々と記述。

### 新構成
1. **タグライン** — minimal RNG ライブラリの一文紹介
2. **デモ録画プレースホルダ** — `<!-- ![hoba demo](docs/demo.gif) -->` をコメントで仕込み（録画は kako-jun が後ほど）
3. **Quickstart** — `[dependencies]` + 4 行の API サンプル、1画面に収まる
4. **Environment quality monitor** — `is_compromised()` / `compromised_depth()` を factual に紹介、frequency/mask は伏せる、`default-features = false` でオプトアウト方法も明示
5. **Demo** — `cargo run --example demo` の案内
6. **Documentation** — docs.rs リンク
7. **Inspired by** — 帆場暎一 + Famicom 2P-mic homage の一節（#14 指示）
8. **License**

### 残作業（Issue #7 残）
- 30秒スクリーン録画は kako-jun が `examples/demo.rs` を回しながら撮影
- `docs/demo.gif` パスにファイルを置けば README の HTML コメントを外して有効化（コメントブロックも一緒に外す）
- crates.io / GitHub レンダリングは公開後に実機確認

## ビルド検証

| | 結果 |
|---|---|
| `cargo build` | OK |
| `cargo test` | 21/21 + doc-test pass |
| `cargo fmt -- --check` | clean |