### PR TITLE
refactor: trim demo output to honor #14 hidden-mode philosophy

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,21 +1,20 @@
 //! Live demo: opens the default mic, prints a roll of `randint(1, 6)` once
 //! per second along with the detector state. Runs until Ctrl+C.
 //!
-//! Try playing an ultrasonic tone (19.0 / 19.5 / 20.0 / 20.5 kHz) near the
-//! mic. The indicator on the right surfaces which 0.5 kHz bucket is dominant
-//! and how many low bits get cleared from `random_u64`.
+//! The indicator on the right surfaces the current monitor state. Try
+//! running it under different ambient acoustic conditions.
 
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-fn bucket_label(depth: u8) -> &'static str {
+fn state_label(depth: u8) -> &'static str {
     match depth {
-        0 => "  --  ",
-        1 => "19.0k!",
-        2 => "19.5k!",
-        3 => "20.0k!",
-        4 => "20.5k!",
-        _ => "  ?   ",
+        0 => " --   ",
+        1 => "mode 1",
+        2 => "mode 2",
+        3 => "mode 3",
+        4 => "mode 4",
+        _ => " ??   ",
     }
 }
 
@@ -33,20 +32,18 @@ fn wall_clock_hms() -> String {
 
 fn main() {
     println!("hoba demo — randint(1, 6) once per second.");
-    println!("Tip: play an ultrasonic tone (19.0–20.5 kHz, 0.5 kHz buckets) near the mic.");
-    println!("State legend: `  --  ` no trigger;  `19.0k!`–`20.5k!` bucket detected (depth 1..4).");
-    println!("When triggered, rolls collapse to {{1, 3, 5}} (LSB cleared).");
+    println!("Watch the `monitor` column as the room conditions change.");
     #[cfg(not(feature = "mic"))]
-    println!("(built without `mic` feature; trigger detection disabled, depth stays 0)");
+    println!("(built without `mic` feature; the monitor stays disabled)");
     println!();
 
     loop {
         let roll = hoba::randint(1, 6);
         let depth = hoba::compromised_depth();
         println!(
-            "{}  roll={roll}  detector={}",
+            "{}  roll={roll}  monitor={}",
             wall_clock_hms(),
-            bucket_label(depth)
+            state_label(depth)
         );
         std::io::stdout().flush().ok();
         std::thread::sleep(Duration::from_secs(1));


### PR DESCRIPTION
## 関連 Issue
refs #14

## 経緯
PR #21 (#6 demo) で導入した \`examples/demo.rs\` の stdout が \`19.0k!\` 〜 \`20.5k!\` のラベルや「play an ultrasonic tone (19.0–20.5 kHz)」のヒントで trigger 周波数を露出していた。Issue #14 の "Famicom 2P-mic style hidden mode" 思想に反するため修正。

## 変更内容

### Before
\`\`\`
hoba demo — randint(1, 6) once per second.
Tip: play an ultrasonic tone (19.0–20.5 kHz, 0.5 kHz buckets) near the mic.
State legend: \`  --  \` no trigger;  \`19.0k!\`–\`20.5k!\` bucket detected (depth 1..4).
When triggered, rolls collapse to {1, 3, 5} (LSB cleared).

21:10:09  roll=2  detector=  --  
21:10:12  roll=5  detector=19.0k!
\`\`\`

### After
\`\`\`
hoba demo — randint(1, 6) once per second.
Watch the \`monitor\` column as the room conditions change.

21:17:10  roll=6  monitor= --   
21:17:13  roll=5  monitor=mode 1
\`\`\`

- ヒント行から kHz 数値を削除、「room conditions change」の汎用表現に
- 凡例行を削除（観察してね、で済む）
- バイアス内容（{1,3,5} に潰れる）の解説も削除
- ラベル \`19.0k!\`〜\`20.5k!\` → \`mode 1\`〜\`mode 4\`、不変の depth 情報は残しつつ周波数は伏せる
- doc コメントも "ultrasonic tone (19.0/...)" → "different ambient acoustic conditions" に書き直し

## #14 の他のアクション

- ✅ README "Inspired by" 節 (Famicom 2P-mic homage) — PR #22 で追加済み
- ✅ 残 issue #8-#13 の language 監査 — "compromised" は \`is_compromised\` API 名で load-bearing、それ以外は既に factual
- ✅ demo の hidden-mode flavor — この PR

\`Detector\` の内部 doc / バケット定数 / FFT 周波数定数は実装詳細として src 内に残るが、ユーザー向け surface (README / demo / 公開 doc) からは除外済み。

## ビルド検証

| | 結果 |
|---|---|
| \`cargo build --example demo\` | OK |
| \`cargo build --example demo --no-default-features\` | OK |
| \`cargo clippy --example demo --all-features -- -D warnings\` | clean |
| \`cargo run --example demo\`（4秒スモーク） | mode 表示で動作 |