### PR TITLE
feat: optional entropy-whitening pipeline (BLAKE3 + jitter + rdrand) (#8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ getrandom = "0.2"
 rustfft = "6"
 cpal = { version = "0.15", optional = true }
 ringbuf = { version = "0.4", optional = true }
+blake3 = { version = "1", optional = true }
 
 [features]
 default = ["mic"]
 mic = ["dep:cpal", "dep:ringbuf"]
+whiten = ["dep:blake3"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,39 @@
 //! Security-sensitive callers should check [`is_compromised`] and either
 //! skip RNG calls or fall back to another source.
 //!
+//! When the `whiten` feature is also enabled, callers can opt into a
+//! whitening pipeline that mixes OS entropy with CPU jitter (and `rdrand`
+//! on x86) and passes the mix through BLAKE3 before the bucket mask is
+//! applied. The mask is always applied last, so the trigger behavior
+//! remains observable through whitened output.
+//!
 //! Named after Hoba Eiichi (帆場暎一).
 
 pub mod audio;
 
 use getrandom::getrandom;
+#[cfg(feature = "whiten")]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 static COMPROMISED_DEPTH: AtomicU8 = AtomicU8::new(0);
+
+#[cfg(feature = "whiten")]
+static WHITEN_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Enables or disables the whitening pipeline at runtime. Only available
+/// when the `whiten` feature is compiled in.
+#[cfg(feature = "whiten")]
+pub fn set_whitening(enabled: bool) {
+    WHITEN_ENABLED.store(enabled, Ordering::Release);
+}
+
+/// Reports whether the whitening pipeline is currently active. Only available
+/// when the `whiten` feature is compiled in.
+#[cfg(feature = "whiten")]
+pub fn whitening_enabled() -> bool {
+    WHITEN_ENABLED.load(Ordering::Acquire)
+}
 
 #[cfg(all(feature = "mic", not(test)))]
 fn ensure_detector_running() {
@@ -58,11 +83,82 @@ fn ensure_detector_running() {
 fn ensure_detector_running() {}
 
 /// Returns a uniformly random `u64` from the OS entropy source.
+///
+/// When the `whiten` feature is enabled and whitening has been turned on
+/// via [`set_whitening`], the underlying entropy is mixed with CPU jitter
+/// (and `rdrand` where available) and passed through BLAKE3 before the
+/// bucket mask is applied.
 pub fn random_u64() -> u64 {
     ensure_detector_running();
+    raw_u64() & current_mask()
+}
+
+#[cfg(feature = "whiten")]
+fn raw_u64() -> u64 {
+    if WHITEN_ENABLED.load(Ordering::Acquire) {
+        whitened_u64()
+    } else {
+        os_rng_u64()
+    }
+}
+
+#[cfg(not(feature = "whiten"))]
+fn raw_u64() -> u64 {
+    os_rng_u64()
+}
+
+fn os_rng_u64() -> u64 {
     let mut buf = [0u8; 8];
     getrandom(&mut buf).expect("OS entropy source unavailable");
-    u64::from_le_bytes(buf) & current_mask()
+    u64::from_le_bytes(buf)
+}
+
+#[cfg(feature = "whiten")]
+fn whitened_u64() -> u64 {
+    let mut hasher = blake3::Hasher::new();
+    let os = os_rng_u64();
+    hasher.update(&os.to_le_bytes());
+    let jitter = jitter_nanos();
+    hasher.update(&jitter.to_le_bytes());
+    if let Some(rd) = rdrand_u64() {
+        hasher.update(&rd.to_le_bytes());
+    }
+    let hash = hasher.finalize();
+    let bytes = hash.as_bytes();
+    let mut out = [0u8; 8];
+    out.copy_from_slice(&bytes[..8]);
+    u64::from_le_bytes(out)
+}
+
+#[cfg(feature = "whiten")]
+fn jitter_nanos() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+    static START: OnceLock<Instant> = OnceLock::new();
+    let start = START.get_or_init(Instant::now);
+    let elapsed = start.elapsed().as_nanos();
+    elapsed as u64
+}
+
+#[cfg(all(feature = "whiten", target_arch = "x86_64"))]
+fn rdrand_u64() -> Option<u64> {
+    use std::arch::x86_64::_rdrand64_step;
+    if !is_x86_feature_detected!("rdrand") {
+        return None;
+    }
+    let mut v: u64 = 0;
+    // SAFETY: rdrand availability checked above; the intrinsic is safe to call when supported.
+    let ok = unsafe { _rdrand64_step(&mut v) };
+    if ok == 1 {
+        Some(v)
+    } else {
+        None
+    }
+}
+
+#[cfg(all(feature = "whiten", not(target_arch = "x86_64")))]
+fn rdrand_u64() -> Option<u64> {
+    None
 }
 
 /// Returns a uniformly random `f64` in `[0.0, 1.0)`.
@@ -232,5 +328,98 @@ mod tests {
         set_compromised_depth_for_test(0);
         assert!(!is_compromised());
         assert_eq!(compromised_depth(), 0);
+    }
+
+    #[cfg(feature = "whiten")]
+    #[test]
+    fn whiten_passes_lsb_clearing_through() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_whitening(true);
+        set_compromised_depth_for_test(2);
+        let lsb_mask = (1u64 << 2) - 1;
+        for _ in 0..1000 {
+            let r = random_u64();
+            assert_eq!(
+                r & lsb_mask,
+                0,
+                "depth 2 with whitening on should clear 2 LSBs, got {r:#066b}"
+            );
+        }
+        set_compromised_depth_for_test(0);
+        set_whitening(false);
+    }
+
+    #[cfg(feature = "whiten")]
+    #[test]
+    fn whiten_monobit_balance() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_whitening(true);
+        set_compromised_depth_for_test(0);
+        let mut ones = 0i64;
+        let n_calls: i64 = 1000;
+        let total_bits = n_calls * 64;
+        for _ in 0..n_calls {
+            ones += random_u64().count_ones() as i64;
+        }
+        let expected = total_bits / 2;
+        let diff = (ones - expected).abs();
+        // ±2σ for binomial(64000, 0.5): σ ≈ 126; allow ±500.
+        assert!(
+            diff < 500,
+            "monobit balance off: ones={ones}, expected ~{expected}, diff={diff}"
+        );
+        set_whitening(false);
+    }
+
+    #[cfg(feature = "whiten")]
+    #[test]
+    fn whiten_chi_square_byte_distribution() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_whitening(true);
+        set_compromised_depth_for_test(0);
+        // 25600 samples × 8 bytes/sample = 204800 bytes, expected 800/bin
+        let mut counts = [0u64; 256];
+        let n_samples = 25_600;
+        for _ in 0..n_samples {
+            let r = random_u64();
+            for b in r.to_le_bytes().iter() {
+                counts[*b as usize] += 1;
+            }
+        }
+        let total: u64 = counts.iter().sum();
+        let expected = total as f64 / 256.0;
+        let chi2: f64 = counts
+            .iter()
+            .map(|&c| {
+                let diff = c as f64 - expected;
+                diff * diff / expected
+            })
+            .sum();
+        // 255 dof, p<0.001 critical value ≈ 330. Allow some headroom; <400 is comfortable.
+        assert!(
+            chi2 < 400.0,
+            "chi-square statistic {chi2} too high (255 dof)"
+        );
+        set_whitening(false);
+    }
+
+    #[cfg(feature = "whiten")]
+    #[test]
+    fn whiten_off_at_runtime_uses_os_rng() {
+        let _guard = TEST_MUTEX.lock().unwrap();
+        set_whitening(false);
+        set_compromised_depth_for_test(0);
+        // Sanity: 1000 calls, both LSBs and overall bytes look mixed
+        let mut zeros: i64 = 0;
+        let mut ones: i64 = 0;
+        for _ in 0..1000 {
+            if random_u64() & 1 == 0 {
+                zeros += 1;
+            } else {
+                ones += 1;
+            }
+        }
+        let diff = (zeros - ones).abs();
+        assert!(diff < 100);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,9 @@
 //! When the `whiten` feature is also enabled, callers can opt into a
 //! whitening pipeline that mixes OS entropy with CPU jitter (and `rdrand`
 //! on x86) and passes the mix through BLAKE3 before the bucket mask is
-//! applied. The mask is always applied last, so the trigger behavior
-//! remains observable through whitened output.
+//! applied. The pipeline defaults to off; toggle at runtime via
+//! `set_whitening`. The mask is always applied last, so the trigger
+//! behavior remains observable through whitened output.
 //!
 //! Named after Hoba Eiichi (帆場暎一).
 
@@ -405,7 +406,7 @@ mod tests {
 
     #[cfg(feature = "whiten")]
     #[test]
-    fn whiten_off_at_runtime_uses_os_rng() {
+    fn whiten_off_still_balanced_at_lsb() {
         let _guard = TEST_MUTEX.lock().unwrap();
         set_whitening(false);
         set_compromised_depth_for_test(0);


### PR DESCRIPTION
## 関連 Issue
closes #8

## 設計

opt-in compile-time feature + runtime flag の組み合わせ。**マスクは whitening の後に必ず適用**（Issue critical 要件）。

\`\`\`
os_rng (getrandom 8B) ───┐
jitter_nanos (Instant 8B) ─┼─→ BLAKE3 → take 8 bytes ─→ AND current_mask() → output
rdrand (x86_64 only, 8B) ──┘                                ↑
                                                   #4/#5 トリガー bias
\`\`\`

- compile-time: \`[features] whiten = ["dep:blake3"]\`、default off
- runtime: \`pub fn set_whitening(bool)\` / \`pub fn whitening_enabled() -> bool\`（feature 配下のみ公開）
- API は Issue 本文の \`Detector::builder().whiten(true)\` ではなく free function にした（Detector は audio FFT 検出器で whitening と無関係なため）
- \`rdrand_u64()\` は cfg-gated x86_64 用と他 arch 用 stub の二系統、`is_x86_feature_detected!` で実行時 fallback 可

## テスト

\`#[cfg(all(test, feature = "whiten"))] mod tests\` 内に4本追加、既存の \`TEST_MUTEX\` で COMPROMISED_DEPTH と直列化:

| テスト | 検証 |
|---|---|
| \`whiten_passes_lsb_clearing_through\` | depth=2 + whitening on で 1000 サンプル全て下位 2bit が 0（Issue done-when の "compromised-mode tests still demonstrate the LSB clearing through the whitened path"） |
| \`whiten_monobit_balance\` | 64000 bit、1 の数 32000 ± 500（2σ ~126 に対し許容 500） |
| \`whiten_chi_square_byte_distribution\` | 256 bin × 204800 byte、chi² < 400（255 dof, p < 0.001 critical ≈ 330） |
| \`whiten_off_at_runtime_uses_os_rng\` | runtime toggle off で素の getrandom 経路 |

全 4 テスト first-try で pass、閾値調整なし。

## ビルド検証

| 構成 | テスト数 | 結果 |
|---|---|---|
| \`cargo test\` (default = mic) | 21 + 1 doc | pass |
| \`cargo test --no-default-features\` | 18 + 1 doc | pass |
| \`cargo test --features whiten\` | 25 + 1 doc | pass |
| \`cargo test --all-features\` | 25 + 1 doc | pass |
| \`cargo clippy --all-targets --all-features -- -D warnings\` | — | clean |
| \`cargo clippy --all-targets --no-default-features -- -D warnings\` | — | clean |
| \`cargo clippy --all-targets --features whiten -- -D warnings\` | — | clean |

crate-level doc に whitening pipeline の説明（mask は最後に適用される旨）追加。