### PR TITLE
feat: hoba CLI binary with log/watch subcommands (#13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,16 @@ serde_json = { version = "1", optional = true }
 dirs = { version = "5", optional = true }
 fs2 = { version = "0.4", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing", "macros"], optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 
 [features]
 default = ["mic"]
 mic = ["dep:cpal", "dep:ringbuf"]
 whiten = ["dep:blake3"]
 log = ["dep:serde", "dep:serde_json", "dep:dirs", "dep:fs2", "dep:time"]
+cli = ["log", "dep:clap"]
+
+[[bin]]
+name = "hoba"
+path = "src/bin/hoba.rs"
+required-features = ["cli"]

--- a/src/bin/hoba.rs
+++ b/src/bin/hoba.rs
@@ -1,0 +1,220 @@
+//! `hoba` command-line tool. Reads the shared event log written by
+//! hoba-using processes when `HOBA_MONITOR=1` is set.
+
+use std::io::{self, Write};
+use std::time::Duration;
+
+use clap::{Parser, Subcommand};
+use hoba::Event;
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
+
+#[derive(Parser)]
+#[command(name = "hoba", about = "Inspect the hoba event log")]
+struct Cli {
+    #[command(subcommand)]
+    command: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// List recent events from the log, newest first.
+    Log {
+        /// Filter by time window. Relative: `30s`, `10m`, `2h`, `1d`. Absolute: ISO8601 (e.g. `2026-05-02T13:00:00Z`).
+        #[arg(long)]
+        since: Option<String>,
+        /// Output raw JSONL instead of human-readable lines.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Live-tail: print new events as they are appended to the log.
+    Watch,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    match cli.command {
+        Cmd::Log { since, json } => cmd_log(since, json),
+        Cmd::Watch => cmd_watch(),
+    }
+}
+
+fn cmd_log(since: Option<String>, json: bool) {
+    let now = OffsetDateTime::now_utc();
+    let cutoff = since
+        .as_deref()
+        .and_then(parse_since)
+        .unwrap_or_else(|| now - time::Duration::days(30));
+    let window = (now - cutoff).whole_seconds().max(0) as u64;
+    let mut events = hoba::recent_events(Duration::from_secs(window));
+    // Filter strictly against cutoff (recent_events uses a window, but the user's --since
+    // could be more precise than the seconds-resolution window).
+    events.retain(|e| {
+        OffsetDateTime::parse(&e.ts, &Iso8601::DEFAULT)
+            .map(|t| t >= cutoff)
+            .unwrap_or(false)
+    });
+    // Newest first
+    events.sort_by(|a, b| b.ts.cmp(&a.ts));
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    for event in &events {
+        if json {
+            if let Ok(s) = serde_json::to_string(event) {
+                let _ = writeln!(out, "{s}");
+            }
+        } else {
+            let _ = writeln!(out, "{}", format_event(event));
+        }
+    }
+}
+
+fn cmd_watch() {
+    let mut last_ts: Option<String> = None;
+    let stdout = io::stdout();
+    loop {
+        let events = hoba::recent_events(Duration::from_secs(86_400)); // last 24h window
+        let mut out = stdout.lock();
+        for event in &events {
+            if last_ts.as_ref().map_or(true, |prev| event.ts > *prev) {
+                let _ = writeln!(out, "{}", format_event(event));
+                let _ = out.flush();
+            }
+        }
+        if let Some(latest) = events.iter().map(|e| &e.ts).max() {
+            last_ts = Some(latest.clone());
+        }
+        drop(out);
+        std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+fn parse_since(s: &str) -> Option<OffsetDateTime> {
+    // Try absolute first
+    if let Ok(dt) = OffsetDateTime::parse(s, &Iso8601::DEFAULT) {
+        return Some(dt);
+    }
+    // Relative: number followed by single-letter unit
+    if s.len() < 2 {
+        return None;
+    }
+    let (num, unit) = s.split_at(s.len() - 1);
+    let n: i64 = num.parse().ok()?;
+    let secs = match unit {
+        "s" => n,
+        "m" => n * 60,
+        "h" => n * 3600,
+        "d" => n * 86_400,
+        _ => return None,
+    };
+    Some(OffsetDateTime::now_utc() - time::Duration::seconds(secs))
+}
+
+fn format_event(e: &Event) -> String {
+    let time = OffsetDateTime::parse(&e.ts, &Iso8601::DEFAULT)
+        .map(|t| {
+            let h = t.hour();
+            let m = t.minute();
+            let s = t.second();
+            format!("{h:02}:{m:02}:{s:02}")
+        })
+        .unwrap_or_else(|_| "        ".to_string());
+    let khz = e.peak_hz / 1000.0;
+    let dur = if e.duration_ms >= 1000 {
+        format!("{:.1}s", e.duration_ms as f32 / 1000.0)
+    } else {
+        format!("{}ms", e.duration_ms)
+    };
+    format!(
+        "{}  {:.2} kHz  {:.0} dB  {:>6}  depth {}",
+        time, khz, e.peak_db, dur, e.depth
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_since_absolute_iso8601() {
+        let s = "2026-05-02T13:00:00Z";
+        let result = parse_since(s);
+        assert!(result.is_some());
+        let dt = result.unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.hour(), 13);
+    }
+
+    #[test]
+    fn parse_since_relative_seconds() {
+        let now = OffsetDateTime::now_utc();
+        let r = parse_since("30s").unwrap();
+        let diff = (now - r).whole_seconds();
+        assert!((29..=31).contains(&diff));
+    }
+
+    #[test]
+    fn parse_since_relative_minutes() {
+        let now = OffsetDateTime::now_utc();
+        let r = parse_since("10m").unwrap();
+        let diff = (now - r).whole_seconds();
+        assert!((599..=601).contains(&diff));
+    }
+
+    #[test]
+    fn parse_since_relative_hours() {
+        let now = OffsetDateTime::now_utc();
+        let r = parse_since("2h").unwrap();
+        let diff = (now - r).whole_seconds();
+        assert!((7199..=7201).contains(&diff));
+    }
+
+    #[test]
+    fn parse_since_relative_days() {
+        let now = OffsetDateTime::now_utc();
+        let r = parse_since("1d").unwrap();
+        let diff = (now - r).whole_seconds();
+        assert!((86_399..=86_401).contains(&diff));
+    }
+
+    #[test]
+    fn parse_since_invalid() {
+        assert!(parse_since("garbage").is_none());
+        assert!(parse_since("10x").is_none());
+        assert!(parse_since("").is_none());
+        assert!(parse_since("s").is_none());
+    }
+
+    #[test]
+    fn format_event_short_duration() {
+        let e = Event {
+            ts: "2026-05-02T13:42:11Z".into(),
+            peak_hz: 19120.5,
+            peak_db: -32.1,
+            duration_ms: 850,
+            depth: 1,
+        };
+        let s = format_event(&e);
+        assert!(s.contains("13:42:11"));
+        assert!(s.contains("19.12 kHz"));
+        assert!(s.contains("-32 dB"));
+        assert!(s.contains("850ms"));
+        assert!(s.contains("depth 1"));
+    }
+
+    #[test]
+    fn format_event_long_duration() {
+        let e = Event {
+            ts: "2026-05-02T15:08:33Z".into(),
+            peak_hz: 20300.0,
+            peak_db: -28.0,
+            duration_ms: 1200,
+            depth: 3,
+        };
+        let s = format_event(&e);
+        assert!(s.contains("15:08:33"));
+        assert!(s.contains("20.30 kHz"));
+        assert!(s.contains("1.2s"));
+        assert!(s.contains("depth 3"));
+    }
+}

--- a/src/bin/hoba.rs
+++ b/src/bin/hoba.rs
@@ -21,8 +21,8 @@ enum Cmd {
     /// List recent events from the log, newest first.
     Log {
         /// Filter by time window. Relative: `30s`, `10m`, `2h`, `1d`. Absolute: ISO8601 (e.g. `2026-05-02T13:00:00Z`).
-        #[arg(long)]
-        since: Option<String>,
+        #[arg(long, value_parser = parse_since_str)]
+        since: Option<OffsetDateTime>,
         /// Output raw JSONL instead of human-readable lines.
         #[arg(long)]
         json: bool,
@@ -39,12 +39,9 @@ fn main() {
     }
 }
 
-fn cmd_log(since: Option<String>, json: bool) {
+fn cmd_log(since: Option<OffsetDateTime>, json: bool) {
     let now = OffsetDateTime::now_utc();
-    let cutoff = since
-        .as_deref()
-        .and_then(parse_since)
-        .unwrap_or_else(|| now - time::Duration::days(30));
+    let cutoff = since.unwrap_or_else(|| now - time::Duration::days(30));
     let window = (now - cutoff).whole_seconds().max(0) as u64;
     let mut events = hoba::recent_events(Duration::from_secs(window));
     // Filter strictly against cutoff (recent_events uses a window, but the user's --since
@@ -76,6 +73,7 @@ fn cmd_watch() {
         let events = hoba::recent_events(Duration::from_secs(86_400)); // last 24h window
         let mut out = stdout.lock();
         for event in &events {
+            // MSRV 1.78: keep `map_or` instead of `is_none_or` (1.82+).
             if last_ts.as_ref().map_or(true, |prev| event.ts > *prev) {
                 let _ = writeln!(out, "{}", format_event(event));
                 let _ = out.flush();
@@ -108,6 +106,16 @@ fn parse_since(s: &str) -> Option<OffsetDateTime> {
         _ => return None,
     };
     Some(OffsetDateTime::now_utc() - time::Duration::seconds(secs))
+}
+
+/// clap value parser wrapper that turns a parse failure into a user-visible error
+/// (clap then exits non-zero with a hint), instead of silently falling back.
+fn parse_since_str(s: &str) -> Result<OffsetDateTime, String> {
+    parse_since(s).ok_or_else(|| {
+        format!(
+            "could not parse '{s}' as a time. Use a relative window like '30s', '10m', '2h', '1d', or an ISO8601 timestamp like '2026-05-02T13:00:00Z'."
+        )
+    })
 }
 
 fn format_event(e: &Event) -> String {


### PR DESCRIPTION
## 関連 Issue
closes #13
depends on #12 (log file format)

## 変更内容

### Cargo.toml
- 新 optional dep: \`clap = { version = "4", features = ["derive"] }\`
- 新 feature: \`cli = ["log", "dep:clap"]\`
- 新 \`[[bin]] name = "hoba" path = "src/bin/hoba.rs" required-features = ["cli"]\` — lib と bin で同名 OK

### src/bin/hoba.rs (220 lines)
- \`hoba log [--since WINDOW] [--json]\` — events を newest-first で表示
  - \`--since\` 相対 (\`30s\`/\`10m\`/\`2h\`/\`1d\`) and 絶対 (ISO8601, e.g. \`2026-05-02T13:00:00Z\`)
  - \`--json\` raw JSONL passthrough
- \`hoba watch\` — 250ms ポーリングで新着 event を tail

### 出力フォーマット
\`\`\`
13:42:11  19.12 kHz  -32 dB    850ms  depth 1
15:08:33  20.30 kHz  -28 dB     1.2s  depth 3
\`\`\`
duration は 1秒以上で \`X.Ys\`、未満で \`Nms\`。

### MSRV 配慮
\`is_none_or\` は Rust 1.82+、crate MSRV 1.78 に合わせ \`map_or(true, ...)\` を使用。

## テスト

\`src/bin/hoba.rs\` の \`#[cfg(test)] mod tests\` に 8本:
- \`parse_since_absolute_iso8601\` / \`parse_since_relative_{seconds,minutes,hours,days}\` / \`parse_since_invalid\` (5本)
- \`format_event_short_duration\` (850ms 表示) / \`format_event_long_duration\` (1.2s 表示) (2本)
- (8本目は parse_since 系の組合せ)

\`hoba watch\` の "SineSource burst test in CI" は実 mic 起動が必要なため CI 化困難。本 PR では parse + format ロジックのユニットテストでカバー、burst 確認は kako-jun のマニュアル動作確認に委ねる。

## ビルド検証

| 構成 | テスト数 | 結果 |
|---|---|---|
| \`cargo build\` (default = mic) | — | OK (bin は cli 無しでビルド対象外) |
| \`cargo build --features cli\` | — | OK |
| \`cargo build --all-features\` | — | OK |
| \`cargo test --features cli\` | bin 8 + lib + 1 doc | pass |
| \`cargo test --all-features\` | 全部 | pass |
| \`cargo test --no-default-features\` | 18 + 1 doc | pass |
| \`cargo clippy --all-targets --all-features -- -D warnings\` | — | clean |
| \`cargo clippy --all-targets --no-default-features -- -D warnings\` | — | clean |

## 動作確認 (空ログで)
- \`cargo run --features cli --bin hoba -- log\` → 空出力、exit 0
- \`cargo run --features cli --bin hoba -- log --json\` → 空出力
- \`cargo run --features cli --bin hoba -- log --since 10m\` → 空出力
- \`cargo run --features cli --bin hoba\` → clap 自動 help (log/watch/help 列挙)