### PR TITLE
v0.3.0 hardening: fs4 + atomic rename + dropped counter + audio_active diagnostic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ blake3 = { version = "1", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 dirs = { version = "5", optional = true }
-fs2 = { version = "0.4", optional = true }
+fs4 = { version = "1", optional = true }
 time = { version = "0.3", features = ["formatting", "parsing", "macros"], optional = true }
 clap = { version = "4", features = ["derive"], optional = true }
 
@@ -29,7 +29,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 default = ["mic"]
 mic = ["dep:cpal", "dep:ringbuf"]
 whiten = ["dep:blake3"]
-log = ["dep:serde", "dep:serde_json", "dep:dirs", "dep:fs2", "dep:time"]
+log = ["dep:serde", "dep:serde_json", "dep:dirs", "dep:fs4", "dep:time"]
 cli = ["log", "dep:clap"]
 
 [[bin]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoba"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["kako-jun"]
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,21 @@ pub mod audio;
 use getrandom::getrandom;
 #[cfg(feature = "whiten")]
 use std::sync::atomic::AtomicBool;
+#[cfg(feature = "log")]
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::{AtomicU8, Ordering};
 
 static COMPROMISED_DEPTH: AtomicU8 = AtomicU8::new(0);
 
 #[cfg(feature = "whiten")]
 static WHITEN_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Process-global tally of events the on-disk log silently dropped because
+/// some step in `append_event_with_retention` failed (open / lock / temp
+/// open / write / flush / fsync / rename). Bumped only inside that function;
+/// surfaced via [`dropped_event_count`].
+#[cfg(feature = "log")]
+static DROPPED_EVENTS: AtomicU64 = AtomicU64::new(0);
 
 /// Enables or disables the whitening pipeline at runtime. Only available
 /// when the `whiten` feature is compiled in.
@@ -317,6 +326,26 @@ pub fn retention_days() -> u32 {
     RETENTION_DAYS.load(std::sync::atomic::Ordering::Acquire) as u32
 }
 
+/// Returns the number of events the background detector has tried — and
+/// failed — to write to the on-disk log over the lifetime of this process.
+///
+/// The counter is incremented whenever
+/// `append_event_with_retention` bails out before the temp file is
+/// successfully renamed over `events.jsonl`: missing log directory, lock
+/// contention, full disk, fsync error, rename error, etc.
+///
+/// Useful for diagnosing why a host running with `HOBA_MONITOR=1` is
+/// producing a sparser-than-expected log: a non-zero count means the writes
+/// reached the function and were rejected by the filesystem path, not that
+/// the detector itself failed to fire.
+///
+/// The counter is process-global and never resets while the process is
+/// alive; callers that want a delta should snapshot before and after.
+#[cfg(feature = "log")]
+pub fn dropped_event_count() -> u64 {
+    DROPPED_EVENTS.load(Ordering::Acquire)
+}
+
 // Only used inside the detector thread (gated on `mic` & `not(test)`).
 // Compiling under `--all-features` plus tests would otherwise warn dead-code.
 #[cfg(all(feature = "log", feature = "mic", not(test)))]
@@ -409,6 +438,7 @@ fn append_event_with_retention(event: &Event) {
     use time::format_description::well_known::Iso8601;
 
     let Some(path) = log_path() else {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         return;
     };
 
@@ -436,6 +466,7 @@ fn append_event_with_retention(event: &Event) {
         .truncate(false)
         .open(&lock_path)
     else {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         return;
     };
     // `lock_file` is owned for the duration of the critical section below; the
@@ -445,6 +476,7 @@ fn append_event_with_retention(event: &Event) {
     // the trait so we keep working with the toolchain's MSRV (1.78) where
     // `File::lock` is not yet inherent.
     if fs4::FileExt::lock(&lock_file).is_err() {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         return;
     }
 
@@ -493,20 +525,24 @@ fn append_event_with_retention(event: &Event) {
         .truncate(true)
         .open(&tmp_path)
     else {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = fs4::FileExt::unlock(&lock_file);
         return;
     };
     if tmp.write_all(new_contents.as_bytes()).is_err() {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
         let _ = fs4::FileExt::unlock(&lock_file);
         return;
     }
     if tmp.flush().is_err() {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
         let _ = fs4::FileExt::unlock(&lock_file);
         return;
     }
     if tmp.sync_data().is_err() {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
         let _ = fs4::FileExt::unlock(&lock_file);
         return;
@@ -515,6 +551,7 @@ fn append_event_with_retention(event: &Event) {
     // on the source can interfere with rename; closing it first is portable.
     drop(tmp);
     if std::fs::rename(&tmp_path, &path).is_err() {
+        DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
         let _ = fs4::FileExt::unlock(&lock_file);
         return;
@@ -940,5 +977,68 @@ mod log_tests {
 
         std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn dropped_count_zero_on_normal_append() {
+        // The counter is process-global and shared across all tests in the
+        // same binary; snapshot before, append a known number of events, and
+        // assert the delta is 0. Comparing against raw 0 would fail under
+        // any other test in this module that intentionally exercises a
+        // failure path.
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = unique_tmp_dir("dropped-zero");
+        let path = dir.join("events.jsonl");
+        std::fs::remove_file(&path).ok();
+        std::env::set_var("HOBA_LOG_PATH_OVERRIDE", &path);
+
+        let before = dropped_event_count();
+        for i in 0..5 {
+            append_event_with_retention(&Event {
+                ts: now_iso(),
+                peak_hz: 19_000.0 + i as f32,
+                peak_db: -25.0,
+                duration_ms: 100,
+                depth: 1,
+            });
+        }
+        let after = dropped_event_count();
+        assert_eq!(
+            after - before,
+            0,
+            "normal appends should not bump the dropped counter (before={before}, after={after})"
+        );
+
+        std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn dropped_count_increments_on_unwritable_path() {
+        // /dev/null is not a directory, so create_dir_all on a path beneath
+        // it always fails. log_path() returns None in that case and
+        // append_event_with_retention takes its first dropped-counter branch.
+        // This is a deterministic failure across Linux and macOS CI.
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let unwritable = std::path::PathBuf::from("/dev/null/hoba-not-a-dir/events.jsonl");
+        std::env::set_var("HOBA_LOG_PATH_OVERRIDE", &unwritable);
+
+        let before = dropped_event_count();
+        append_event_with_retention(&Event {
+            ts: now_iso(),
+            peak_hz: 19_000.0,
+            peak_db: -25.0,
+            duration_ms: 100,
+            depth: 1,
+        });
+        let after = dropped_event_count();
+        assert_eq!(
+            after - before,
+            1,
+            "an unwritable log path should bump the dropped counter exactly once \
+             (before={before}, after={after})"
+        );
+
+        std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,7 +405,6 @@ fn read_all_events() -> Vec<Event> {
 
 #[cfg(feature = "log")]
 fn append_event_with_retention(event: &Event) {
-    use fs2::FileExt;
     use std::io::{Read, Seek, SeekFrom, Write};
     use time::format_description::well_known::Iso8601;
 
@@ -421,7 +420,13 @@ fn append_event_with_retention(event: &Event) {
     else {
         return;
     };
-    if file.lock_exclusive().is_err() {
+    // `file` is owned for the duration of the critical section below; the lock is
+    // released when `file` is dropped at the end of the function. fs4's `lock()`
+    // mirrors `std::fs::File::lock`, acquiring an exclusive flock(2) on Unix and
+    // LockFileEx on Windows. Routed explicitly through the trait so we keep
+    // working with the toolchain's MSRV (1.78) where `File::lock` is not yet
+    // inherent.
+    if fs4::FileExt::lock(&file).is_err() {
         return;
     }
 
@@ -452,7 +457,7 @@ fn append_event_with_retention(event: &Event) {
         let _ = writeln!(file, "{new_line}");
     }
     let _ = file.flush();
-    let _ = fs2::FileExt::unlock(&file);
+    let _ = fs4::FileExt::unlock(&file);
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,20 @@
 //! appends one JSON line to a per-host event log on every quiet → trigger
 //! → quiet cycle. Read recent events back via [`recent_events`].
 //!
+//! For diagnosing a quiet host, three read-only counters complement
+//! [`is_compromised`] / [`compromised_depth`]:
+//! [`audio_active`] reports whether the background detector is reading
+//! live audio (mic feature), and [`dropped_event_count`] tallies events
+//! the on-disk log silently rejected (log feature). Together they
+//! distinguish "no triggers happened" from "the monitor never started"
+//! from "every write was thrown away".
+//!
 //! Named after Hoba Eiichi (帆場暎一).
 
 pub mod audio;
 
 use getrandom::getrandom;
-#[cfg(feature = "whiten")]
+#[cfg(any(feature = "whiten", feature = "mic"))]
 use std::sync::atomic::AtomicBool;
 #[cfg(feature = "log")]
 use std::sync::atomic::AtomicU64;
@@ -42,6 +50,13 @@ static COMPROMISED_DEPTH: AtomicU8 = AtomicU8::new(0);
 
 #[cfg(feature = "whiten")]
 static WHITEN_ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Set to `true` by the detector thread once it has successfully opened the
+/// default audio input and is reading samples; cleared back to `false` when
+/// the thread exits (mic disappears, panic, etc.). Surfaced via
+/// [`audio_active`].
+#[cfg(feature = "mic")]
+static MIC_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// Process-global tally of events the on-disk log silently dropped because
 /// some step in `append_event_with_retention` failed (open / lock / temp
@@ -79,10 +94,13 @@ fn ensure_detector_running() {
     INIT.call_once(|| {
         // If the detector loop ever exits (panic, mic disappears), clear the depth so
         // the library degrades to plain RNG instead of latching the last compromised state.
+        // Same goes for MIC_ACTIVE: any callers polling audio_active() should observe the
+        // monitor going inactive once the thread is gone.
         struct ClearOnDrop;
         impl Drop for ClearOnDrop {
             fn drop(&mut self) {
                 COMPROMISED_DEPTH.store(0, Ordering::Release);
+                MIC_ACTIVE.store(false, Ordering::Release);
             }
         }
         let _ = std::thread::Builder::new()
@@ -93,6 +111,9 @@ fn ensure_detector_running() {
                 if !mic.is_active() {
                     return;
                 }
+                // Mic opened successfully; signal to audio_active() callers that the
+                // monitor is now reading live audio.
+                MIC_ACTIVE.store(true, Ordering::Release);
                 let mut detector = audio::Detector::with_source(mic);
                 #[cfg(feature = "log")]
                 let mut active: Option<EventInProgress> = None;
@@ -270,6 +291,35 @@ pub fn is_compromised() -> bool {
 pub fn compromised_depth() -> u8 {
     ensure_detector_running();
     COMPROMISED_DEPTH.load(Ordering::Acquire)
+}
+
+/// Returns `true` if the background mic monitor is actively reading audio
+/// from a live input device.
+///
+/// Returns `false` when the `mic` feature is off, when `HOBA_MONITOR=1` is
+/// unset, when the device failed to open (no device, permission denied,
+/// no compatible sample format), or when the monitor thread has not yet
+/// had a chance to initialise.
+///
+/// **Startup race:** the first call after the gating env var is set merely
+/// schedules the detector thread; it has not yet run `MicSource::new()`,
+/// so this function may briefly return `false`. Callers wanting a
+/// definitive answer should poll for ~100 ms after the first call;
+/// subsequent calls converge to the actual state.
+///
+/// Lazily starts the background mic monitor on first use, like
+/// [`is_compromised`] / [`compromised_depth`].
+#[cfg(feature = "mic")]
+pub fn audio_active() -> bool {
+    ensure_detector_running();
+    MIC_ACTIVE.load(Ordering::Acquire)
+}
+
+/// Stub returned when the `mic` feature is disabled — the mic monitor cannot
+/// run, so the answer is always `false`.
+#[cfg(not(feature = "mic"))]
+pub fn audio_active() -> bool {
+    false
 }
 
 fn current_mask() -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,18 +520,26 @@ fn append_event_with_retention(event: &Event) {
         return;
     };
     // `lock_file` is owned for the duration of the critical section below; the
-    // lock is released when the handle is dropped at the end of the function.
-    // fs4's `lock()` mirrors `std::fs::File::lock`, acquiring an exclusive
-    // flock(2) on Unix and LockFileEx on Windows. Routed explicitly through
-    // the trait so we keep working with the toolchain's MSRV (1.78) where
-    // `File::lock` is not yet inherent.
+    // lock is released when the handle is dropped. Routed explicitly through
+    // the trait so it keeps working under future MSRV bumps where the inherent
+    // `std::fs::File::lock` shadows the trait method.
     if fs4::FileExt::lock(&lock_file).is_err() {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         return;
     }
 
-    // Read the canonical file. Missing file is fine — first write.
-    let contents = std::fs::read_to_string(&path).unwrap_or_default();
+    // Read the canonical file. Missing file is fine (first write); any other
+    // I/O failure (transient EIO, permission flap) must abort — silently
+    // discarding the read and rewriting the tmp would clobber the existing
+    // history with just the new event, breaking the crash-safety contract.
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(_) => {
+            DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
+            return;
+        }
+    };
 
     let cutoff = time::OffsetDateTime::now_utc()
         - time::Duration::days(RETENTION_DAYS.load(std::sync::atomic::Ordering::Acquire));
@@ -569,6 +577,9 @@ fn append_event_with_retention(event: &Event) {
         None => std::path::PathBuf::from(&tmp_name),
     };
 
+    // The `lock_file` handle is held to the end of the function; its Drop
+    // releases the flock automatically. Adding explicit unlock calls in each
+    // error tail is redundant and clutters the failure paths.
     let Ok(mut tmp) = std::fs::OpenOptions::new()
         .write(true)
         .create(true)
@@ -576,25 +587,21 @@ fn append_event_with_retention(event: &Event) {
         .open(&tmp_path)
     else {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
-        let _ = fs4::FileExt::unlock(&lock_file);
         return;
     };
     if tmp.write_all(new_contents.as_bytes()).is_err() {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
-        let _ = fs4::FileExt::unlock(&lock_file);
         return;
     }
     if tmp.flush().is_err() {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
-        let _ = fs4::FileExt::unlock(&lock_file);
         return;
     }
     if tmp.sync_data().is_err() {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
-        let _ = fs4::FileExt::unlock(&lock_file);
         return;
     }
     // Drop the temp handle before renaming. On Windows, leaving an open handle
@@ -603,11 +610,8 @@ fn append_event_with_retention(event: &Event) {
     if std::fs::rename(&tmp_path, &path).is_err() {
         DROPPED_EVENTS.fetch_add(1, Ordering::AcqRel);
         let _ = std::fs::remove_file(&tmp_path);
-        let _ = fs4::FileExt::unlock(&lock_file);
-        return;
     }
-
-    let _ = fs4::FileExt::unlock(&lock_file);
+    drop(lock_file);
 }
 
 #[cfg(test)]
@@ -1090,5 +1094,42 @@ mod log_tests {
         );
 
         std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
+    }
+
+    #[test]
+    fn dropped_count_increments_on_read_failure_keeps_history() {
+        // If `events.jsonl` exists but is unreadable (here: replaced by a
+        // directory of the same name so read_to_string returns EISDIR), we
+        // must abort and bump the counter — NOT silently treat the read
+        // failure as "missing file" and rewrite the log with only the new
+        // event. The latter would clobber any existing history.
+        let _guard = LOG_TEST_MUTEX.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("hoba-test-readfail-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("events.jsonl");
+        // Make `path` itself a directory so `read_to_string(&path)` returns
+        // an error other than NotFound.
+        std::fs::create_dir_all(&path).unwrap();
+        std::env::set_var("HOBA_LOG_PATH_OVERRIDE", &path);
+
+        let before = dropped_event_count();
+        append_event_with_retention(&Event {
+            ts: now_iso(),
+            peak_hz: 19_000.0,
+            peak_db: -25.0,
+            duration_ms: 100,
+            depth: 1,
+        });
+        let after = dropped_event_count();
+        assert_eq!(
+            after - before,
+            1,
+            "read failure on existing log path must bump the dropped counter \
+             exactly once and leave the on-disk state untouched \
+             (before={before}, after={after})"
+        );
+
+        std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1125,8 +1125,12 @@ mod log_tests {
             after - before,
             1,
             "read failure on existing log path must bump the dropped counter \
-             exactly once and leave the on-disk state untouched \
-             (before={before}, after={after})"
+             exactly once (before={before}, after={after})"
+        );
+        assert!(
+            path.is_dir(),
+            "events.jsonl path must remain a directory — abort before rename \
+             is the contract that preserves history on transient I/O failures"
         );
 
         std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -405,59 +405,122 @@ fn read_all_events() -> Vec<Event> {
 
 #[cfg(feature = "log")]
 fn append_event_with_retention(event: &Event) {
-    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::io::Write;
     use time::format_description::well_known::Iso8601;
 
     let Some(path) = log_path() else {
         return;
     };
-    let Ok(mut file) = std::fs::OpenOptions::new()
+
+    // We coordinate writers through a sibling lock file with a stable path.
+    // The canonical `events.jsonl` is replaced by atomic rename below, so its
+    // inode keeps changing — flock(2) is per-open-file-description, so locking
+    // a path that gets renamed out from under us would not actually serialise
+    // a second writer that opens the new inode after the rename. A dedicated
+    // sibling that is *only* opened-and-locked, never renamed, fixes that.
+    let mut lock_path = path.clone();
+    let lock_name = match path.file_name() {
+        Some(n) => {
+            let mut s = n.to_os_string();
+            s.push(".lock");
+            s
+        }
+        None => std::ffi::OsString::from("events.jsonl.lock"),
+    };
+    lock_path.set_file_name(&lock_name);
+
+    let Ok(lock_file) = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
-        .open(&path)
+        .open(&lock_path)
     else {
         return;
     };
-    // `file` is owned for the duration of the critical section below; the lock is
-    // released when `file` is dropped at the end of the function. fs4's `lock()`
-    // mirrors `std::fs::File::lock`, acquiring an exclusive flock(2) on Unix and
-    // LockFileEx on Windows. Routed explicitly through the trait so we keep
-    // working with the toolchain's MSRV (1.78) where `File::lock` is not yet
-    // inherent.
-    if fs4::FileExt::lock(&file).is_err() {
+    // `lock_file` is owned for the duration of the critical section below; the
+    // lock is released when the handle is dropped at the end of the function.
+    // fs4's `lock()` mirrors `std::fs::File::lock`, acquiring an exclusive
+    // flock(2) on Unix and LockFileEx on Windows. Routed explicitly through
+    // the trait so we keep working with the toolchain's MSRV (1.78) where
+    // `File::lock` is not yet inherent.
+    if fs4::FileExt::lock(&lock_file).is_err() {
         return;
     }
 
-    let mut contents = String::new();
-    let _ = file.seek(SeekFrom::Start(0));
-    let _ = file.read_to_string(&mut contents);
+    // Read the canonical file. Missing file is fine — first write.
+    let contents = std::fs::read_to_string(&path).unwrap_or_default();
 
     let cutoff = time::OffsetDateTime::now_utc()
         - time::Duration::days(RETENTION_DAYS.load(std::sync::atomic::Ordering::Acquire));
-    let kept: Vec<&str> = contents
-        .lines()
-        .filter(|line| {
-            serde_json::from_str::<Event>(line)
-                .ok()
-                .and_then(|e| time::OffsetDateTime::parse(&e.ts, &Iso8601::DEFAULT).ok())
-                .map(|t| t >= cutoff)
-                .unwrap_or(false)
-        })
-        .collect();
+    let mut new_contents = String::with_capacity(contents.len() + 256);
+    for line in contents.lines() {
+        let keep = serde_json::from_str::<Event>(line)
+            .ok()
+            .and_then(|e| time::OffsetDateTime::parse(&e.ts, &Iso8601::DEFAULT).ok())
+            .map(|t| t >= cutoff)
+            .unwrap_or(false);
+        if keep {
+            new_contents.push_str(line);
+            new_contents.push('\n');
+        }
+    }
     let new_line = serde_json::to_string(event).unwrap_or_default();
-
-    let _ = file.set_len(0);
-    let _ = file.seek(SeekFrom::Start(0));
-    for line in &kept {
-        let _ = writeln!(file, "{line}");
-    }
     if !new_line.is_empty() {
-        let _ = writeln!(file, "{new_line}");
+        new_contents.push_str(&new_line);
+        new_contents.push('\n');
     }
-    let _ = file.flush();
-    let _ = fs4::FileExt::unlock(&file);
+
+    // Sibling temp file so the rename is guaranteed to land on the same
+    // filesystem (POSIX rename(2) and Win32 MoveFileEx atomic rename both
+    // require this). Tagging with the current pid avoids confusing temps left
+    // behind by a previously crashed writer; concurrent writers within the
+    // same process are already serialised by the exclusive lock above.
+    let pid = std::process::id();
+    let mut tmp_name = path
+        .file_name()
+        .map(|n| n.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from("events.jsonl"));
+    tmp_name.push(format!(".tmp.{pid}"));
+    let tmp_path = match path.parent() {
+        Some(parent) => parent.join(&tmp_name),
+        None => std::path::PathBuf::from(&tmp_name),
+    };
+
+    let Ok(mut tmp) = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&tmp_path)
+    else {
+        let _ = fs4::FileExt::unlock(&lock_file);
+        return;
+    };
+    if tmp.write_all(new_contents.as_bytes()).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        let _ = fs4::FileExt::unlock(&lock_file);
+        return;
+    }
+    if tmp.flush().is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        let _ = fs4::FileExt::unlock(&lock_file);
+        return;
+    }
+    if tmp.sync_data().is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        let _ = fs4::FileExt::unlock(&lock_file);
+        return;
+    }
+    // Drop the temp handle before renaming. On Windows, leaving an open handle
+    // on the source can interfere with rename; closing it first is portable.
+    drop(tmp);
+    if std::fs::rename(&tmp_path, &path).is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+        let _ = fs4::FileExt::unlock(&lock_file);
+        return;
+    }
+
+    let _ = fs4::FileExt::unlock(&lock_file);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 関連 Issue
closes #26 closes #27 closes #28 refs #30

## 4 件まとめ

### #26 fs2 → fs4 (deprecated dep の swap)
- \`fs2 = "0.4"\` → \`fs4 = "1"\`、\`log\` feature の dep 名も入れ替え
- \`fs4::FileExt::lock(&file)\` を明示パスで呼ぶ (MSRV 1.78 / Rust 2024 で \`File::lock\` inherent method と shadowing 衝突しないように)
- ロックは安全 (lock 関数が unsafe 化されたのは fs4 0.x、fs4 1.x で再び safe に)

### #27 Crash-safe event log via atomic rename
- 旧: 同一ファイルを \`truncate → write → flush\` (排他ロック保護下、並行性は OK だが crash 不耐)
- 新: \`events.jsonl.lock\` という **stable な sibling lock file** で flock を取り、生データ書き込みは \`events.jsonl.tmp.<pid>\` に書き出して \`sync_data\` 後 \`std::fs::rename\` で atomic 入れ替え
- POSIX 同一 FS / NTFS 同一ディレクトリで rename は atomic、SIGKILL / 電源断でもログは "全旧 or 全新" のいずれかになる
- **bug fix**: 当初 \`events.jsonl\` 自体を lock target にしていたら concurrent test (4 thread × 5 append) が 10/20 events で破綻 → flock(2) は per-open-file-description のため rename 後の inode 分離で別 writer が独立ロック取得していた、専用 \`events.jsonl.lock\` ファイルで解決

### #28 dropped_event_count() で silent failure を計測
- \`static DROPPED_EVENTS: AtomicU64\` 追加、append の全 silent-fail パス (open / lock / write / rename) で \`fetch_add(1, Relaxed)\`
- 公開: \`pub fn dropped_event_count() -> u64\` (feature = "log" 配下)
- "polite by default" は維持 (eprintln/log は無し)、ただし観測口を 1 個だけ開けた

### #30 follow-up: audio_active() diagnostic API
- \`HOBA_MONITOR=1\` が立っているのにマイクが開けない場合 (no device / permission denied / unsupported format)、現状は detector スレッドが silent return → \`is_compromised()\` 永遠に false
- 新: \`static MIC_ACTIVE: AtomicBool\`、detector スレッドが \`MicSource::is_active() == true\` を確認したら true store
- 公開: \`pub fn audio_active() -> bool\` (feature = "mic" 配下、no-mic では stub で false)
- \`ClearOnDrop\` に MIC_ACTIVE = false も追加でスレッド退出時に整合
- 起動直後の race は doc で明記 ("first call after \`HOBA_MONITOR=1\` may return false transiently、~100ms 後に再確認")

### Version: 0.2.0 → **0.3.0**
4 件のうち #26 だけは patch、残 3 件は新公開 API 追加 (semver minor 相当)、まとめて 0.3.0 で出す。

## テスト

- \`cargo test\` (default = mic): 21 unit + 1 doc-test pass
- \`cargo test --no-default-features\`: 18 unit + 1 doc-test pass
- \`cargo test --all-features\`: **33 unit + 8 bin + 1 doc-test pass** (#28 で +2 dropped_count test)
- \`cargo clippy --all-targets --all-features -- -D warnings\`: clean
- \`cargo clippy --all-targets --no-default-features -- -D warnings\`: clean
- \`cargo fmt -- --check\`: clean

## コミット履歴 (5 本、squash merge で 1 つにまとめる)

\`\`\`
4bafdfc chore: kako-jun/hoba#26 migrate fs2 to fs4
7662d5f feat:  kako-jun/hoba#27 atomic-rename event log writes for crash safety
03826d8 feat:  kako-jun/hoba#28 surface silent write failures via dropped_event_count
3dc4201 feat:  kako-jun/hoba#30 expose audio_active() diagnostic for mic monitor
778a6c3 chore: bump version to 0.3.0
\`\`\`