### PR TITLE
feat: single-bucket 1–10 Hz infrasound default with SNR detection (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,46 @@
 # Changelog
 
-## v0.4.0 — Infrasound default
+## v0.4.0 — Infrasound default, SNR-based detection
 
-- **Release default switched to infrasound 1 / 3 / 5 / 10 Hz**, replacing the
-  previous 19–21 kHz ultrasonic placeholder. Aligns the default with the
-  *Patlabor* HOS homage (low-frequency wind resonance) and intentionally
-  removes the ability to fire from consumer speakers. Override with
-  `HOBA_BUCKETS` or `Detector::with_config` if you need a different band.
-- `DetectorConfig` gains two fields: `fft_size` (so the infrasound default can
-  use a 65536-point window for sub-Hz resolution while the audible-test preset
-  stays at 2048) and `bucket_half_width_hz` (so closely-spaced infrasound
-  buckets do not pollute each other). `release_default()` and
-  `audible_test()` populate sensible values; struct-literal callers must add
-  the new fields.
-- `hoba check` self-test still defaults to 19–21 kHz — that band is at least
-  partially playable on consumer hardware; the new infrasound default cannot
-  be meaningfully self-tested without seismic equipment.
-- README: front-loaded a "Why infrasound is the default" section and removed
-  ultrasonic-as-default messaging from the band-picking guide. Restoring the
-  historical ultrasonic band is documented as a one-line env-var override.
+- **Release default switched to a single 1–10 Hz infrasound bucket that fires
+  on frequency presence (SNR ≥ 6 dB) rather than absolute amplitude** —
+  matching *Patlabor 1*'s HOS lore where the trigger is binary, not graded.
+  One bucket centred on 5.5 Hz with `bucket_half_width_hz = 4.5` covers the
+  entire 1–10 Hz window and pushes the mask depth straight to 4 anywhere
+  inside it. Replaces both the previous v0.3.x 19–21 kHz ultrasonic
+  placeholder *and* the early-v0.4 graded 1 / 3 / 5 / 10 Hz iteration.
+- **Detection criterion moved from raw power to dB SNR.** `DetectorConfig`
+  now exposes `snr_threshold_db` instead of `power_threshold`; the bucket
+  fires when its peak beats a per-poll noise-floor estimate (median bin
+  power across `peak_band_hz`, excluding each bucket's own window) by at
+  least the threshold. Default 6 dB ≈ 2× signal-over-noise. The hand-
+  calibrated absolute threshold from v0.3.x is gone — it silently re-tuned
+  with mic gain and room tone, which is the opposite of what "monitor for
+  trigger frequencies" should mean.
+  - **Breaking (pre-1.0):** struct-literal `DetectorConfig` callers must
+    rename `power_threshold` to `snr_threshold_db` and update the unit.
+  - `Detector` gains `noise_floor_db()` and `snr_db()` accessors mirroring
+    `peak_db()`, so live diagnostics can show the same three numbers the
+    detector itself uses.
+- **Env-var contract.** `HOBA_THRESHOLD` is deprecated; use `HOBA_SNR=<dB>`.
+  v0.4.0 still detects `HOBA_THRESHOLD` so it counts as a "set an override"
+  signal for back-compat tooling, but the value itself is ignored — the
+  unit changed and silently reinterpreting the number would surprise
+  callers. `HOBA_DEBUG=1` prints a one-line deprecation note.
+- `DetectorConfig` also gains `fft_size` (65536 for the infrasound default
+  so the 1 Hz end of the band is resolvable; 2048 elsewhere) and
+  `bucket_half_width_hz` (4.5 Hz for the infrasound default so the single
+  bucket spans the full trigger window). Both presets populate sensible
+  values.
+- `hoba check` output gains explicit `peak_db` / `noise_db` / `snr_db`
+  columns; the per-band PASS condition is now `snr_db ≥ snr_threshold_db`.
+  CLI flag `--threshold` is kept as a deprecated alias for `--snr` (both
+  take a dB SNR value). Default sweep band remains 19–21 kHz — it is
+  partially playable on consumer hardware; the infrasound release default
+  cannot be meaningfully self-tested without seismic equipment.
+- README: rewrote "Why infrasound is the default" around the binary-trigger
+  + frequency-presence framing; band-picking guide updated for `HOBA_SNR`
+  and the legacy graded-bucket recipe. Ultrasonic band-picking row removed.
 
 ## v0.3.x — Runtime-configurable buckets, hardening, and `hoba check`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,47 @@
+# Changelog
+
+## v0.4.0 — Infrasound default
+
+- **Release default switched to infrasound 1 / 3 / 5 / 10 Hz**, replacing the
+  previous 19–21 kHz ultrasonic placeholder. Aligns the default with the
+  *Patlabor* HOS homage (low-frequency wind resonance) and intentionally
+  removes the ability to fire from consumer speakers. Override with
+  `HOBA_BUCKETS` or `Detector::with_config` if you need a different band.
+- `DetectorConfig` gains two fields: `fft_size` (so the infrasound default can
+  use a 65536-point window for sub-Hz resolution while the audible-test preset
+  stays at 2048) and `bucket_half_width_hz` (so closely-spaced infrasound
+  buckets do not pollute each other). `release_default()` and
+  `audible_test()` populate sensible values; struct-literal callers must add
+  the new fields.
+- `hoba check` self-test still defaults to 19–21 kHz — that band is at least
+  partially playable on consumer hardware; the new infrasound default cannot
+  be meaningfully self-tested without seismic equipment.
+- README: front-loaded a "Why infrasound is the default" section and removed
+  ultrasonic-as-default messaging from the band-picking guide. Restoring the
+  historical ultrasonic band is documented as a one-line env-var override.
+
+## v0.3.x — Runtime-configurable buckets, hardening, and `hoba check`
+
+- v0.3.1 (PR #35): `DetectorConfig` exposes `buckets`, `power_threshold`,
+  `peak_band_hz`, plus `HOBA_BUCKETS` / `HOBA_THRESHOLD` / `HOBA_PEAK_BAND`
+  env-var overrides. Detector logic reads from the config; const-only paths
+  removed.
+- v0.3.0 (PR #31): on-disk event log gains atomic-rename writes, sibling lock
+  file, retention pruning, and a process-global `dropped_event_count()`
+  diagnostic. `audio_active()` reports whether the background detector ever
+  opened a real input stream.
+- `hoba check` subcommand (PR #33): per-device frequency-response self-test
+  with PASS/FAIL verdict, `--list-devices`, `--bands`, `--threshold`,
+  `--listen-only`, `--input-device` / `--output-device`.
+
+## v0.2.0
+
+- `audible-test` cargo feature: relocates the trigger band to 1–2.5 kHz so
+  the detector can be exercised through ordinary speakers.
+- BABEL example: Patlabor-flavoured demo of the trigger flipping the output.
+
+## v0.1.x
+
+- Initial release: minimal RNG surface (`random`, `randint`, `choice`,
+  `random_bool`) backed by OS entropy; `mic` feature adds the background
+  trigger monitor with bucket-mask depth on `random_u64`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoba"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["kako-jun"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -12,25 +12,38 @@ when you do not need the full surface of `rand`.
 ## Why infrasound is the default
 
 Starting with v0.4.0, the release default of `hoba`'s environmental quality
-monitor watches **infrasound — 1, 3, 5, and 10 Hz**, all well below the human
-audibility floor (~20 Hz). The reasoning is deliberate.
+monitor watches **a single 1–10 Hz infrasound bucket that fires at depth 4
+on frequency presence** — i.e. the moment any tone in 1–10 Hz beats the
+ambient noise floor by at least 6 dB SNR, the detector trips. Two design
+choices matter, and they both come from *Patlabor*:
 
-In *Patlabor: The Movie* (1989), the HOS / バビロンプロジェクト triggers
-through low-frequency wind resonance against tall buildings — never a sound a
-person can hear, never something you could play through a speaker. `hoba`'s
-release default takes that literally: 1 / 3 / 5 / 10 Hz are physically below
-what any consumer playback chain reproduces. A laptop will not trigger this
-default by accident; a phone will not; a YouTube video will not. The only
-sources that reliably reach these frequencies are real environmental events —
-**earthquakes, typhoon gusts, large industrial machinery, big HVAC plants,
-subway trains rolling past**. That "doesn't fire in everyday life" is the
-whole point. The default is supposed to fire on the day you have already
-forgotten you ever depended on `hoba`.
+- **One bucket, one depth.** In *Patlabor: The Movie* (1989), the HOS /
+  バビロンプロジェクト trigger is binary: it fires or it doesn't. There is no
+  "depth 1" or "depth 3" graded version of the building-wind resonance in
+  the film. `hoba`'s release default takes that literally — a single bucket
+  spans 1.0–10.0 Hz, and any tone in that window pushes the mask depth
+  straight to 4.
+- **Frequency presence, not amplitude.** The v0.3.x detector tested an
+  absolute raw-power threshold, which silently re-calibrates with mic gain,
+  room tone, and per-host noise floor. v0.4.0 replaces that with a **6 dB
+  SNR check against a per-poll noise-floor estimate** (median bin power
+  inside the trigger band, excluding the bucket's own window). The question
+  the detector answers is "is the frequency present?", not "is the
+  amplitude over my hand-tuned constant?" — closer to what the HOS lore
+  actually requires.
+
+1–10 Hz is physically below what any consumer playback chain reproduces. A
+laptop will not trigger this default by accident; a phone will not; a
+YouTube video will not. The only sources that reliably reach this band are
+real environmental events — **earthquakes, typhoon gusts, large industrial
+machinery, big HVAC plants, subway trains rolling past**. That "doesn't fire
+in everyday life" is the whole point. The default is supposed to fire on the
+day you have already forgotten you ever depended on `hoba`.
 
 If you actually want a band you can demo through speakers, you have two
-options without recompiling: the `audible-test` cargo feature (1–2.5 kHz), or
-`HOBA_BUCKETS` to point the detector anywhere your hardware can reach. See
-[Configuration](#configuration).
+options without recompiling: the `audible-test` cargo feature (1–2.5 kHz),
+or `HOBA_BUCKETS` to point the detector anywhere your hardware can reach.
+See [Configuration](#configuration).
 
 ## Quickstart
 
@@ -81,19 +94,19 @@ The detector ships with two presets and accepts arbitrary runtime overrides
 ```rust
 use hoba::audio::{Detector, DetectorConfig, MicSource};
 
-// Production default: infrasound 1 / 3 / 5 / 10 Hz, threshold 10_000.
-// Will not fire on consumer audio — by design.
+// Production default: a single 1–10 Hz infrasound bucket at depth 4,
+// 6 dB SNR threshold. Will not fire on consumer audio — by design.
 let cfg = DetectorConfig::release_default();
 
 // Audible-band preset, reachable from a release build (no `audible-test`
 // feature needed). Use this for development, CI, and live demos.
 let cfg = DetectorConfig::audible_test();
 
-// Custom: sub-bass HVAC monitor, 20–50 Hz, lower power threshold.
+// Custom: sub-bass HVAC monitor, 20–50 Hz graded bucket, stricter SNR.
 // Reachable through a bass amp / subwoofer.
 let cfg = DetectorConfig {
     buckets: vec![(20.0, 1), (30.0, 2), (40.0, 3), (50.0, 4)],
-    power_threshold: 1_000.0,
+    snr_threshold_db: 10.0,
     peak_band_hz: (10.0, 60.0),
     sample_rate: 48_000,
     fft_size: 8192,
@@ -108,28 +121,32 @@ let detector = Detector::with_config(MicSource::new(), cfg);
 When `HOBA_MONITOR=1` auto-spawns the detector thread, three optional vars
 override the compile-time default:
 
-| Var               | Format                                 | Example                       |
-| ----------------- | -------------------------------------- | ----------------------------- |
-| `HOBA_BUCKETS`    | `<center_hz>:<depth>,…` (depth 1..=4)  | `HOBA_BUCKETS=20:1,30:2,40:3,50:4` |
-| `HOBA_THRESHOLD`  | non-negative number (raw band power)   | `HOBA_THRESHOLD=1000`         |
-| `HOBA_PEAK_BAND`  | `<lo_hz>:<hi_hz>` (peak reporting band)| `HOBA_PEAK_BAND=10:60`        |
+| Var              | Format                                    | Example                            |
+| ---------------- | ----------------------------------------- | ---------------------------------- |
+| `HOBA_BUCKETS`   | `<center_hz>:<depth>,…` (depth 1..=4)     | `HOBA_BUCKETS=1:1,3:2,5:3,10:4`    |
+| `HOBA_SNR`       | non-negative dB SNR threshold (default 6) | `HOBA_SNR=10`                      |
+| `HOBA_PEAK_BAND` | `<lo_hz>:<hi_hz>` (peak / floor band)     | `HOBA_PEAK_BAND=10:60`             |
 
-Parse failures fall back silently to the default. Set `HOBA_DEBUG=1` to surface
-them on stderr.
+Parse failures fall back silently to the default. Set `HOBA_DEBUG=1` to
+surface them on stderr.
+
+> **Deprecated since v0.4.0:** `HOBA_THRESHOLD` was the v0.3.x raw band-power
+> knob. Its unit (post-FFT power) does not translate to the new dB SNR
+> threshold, so v0.4.0 ignores the value and prints a one-line deprecation
+> warning under `HOBA_DEBUG=1`. Use `HOBA_SNR` instead.
 
 ### Picking a band
 
-| Use case                                               | Suggested config                                                  |
-| ------------------------------------------------------ | ----------------------------------------------------------------- |
-| Infrasound 1–10 Hz (default — earthquake, HVAC, gusts) | leave unset — release default                                     |
-| Sub-bass 20–50 Hz (bass amp, subway, big HVAC)         | `HOBA_BUCKETS=20:1,30:2,40:3,50:4` `HOBA_THRESHOLD=1000`          |
-| Audible-test 1–2.5 kHz (CI / live demos)               | `HOBA_BUCKETS=1000:1,1500:2,2000:3,2500:4` `HOBA_THRESHOLD=100`   |
+| Use case                                                 | Suggested config                                            |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| Infrasound 1–10 Hz (default — earthquake, HVAC, gusts)   | leave unset — release default                               |
+| Graded infrasound 1 / 3 / 5 / 10 Hz (legacy v0.3 layout) | `HOBA_BUCKETS=1:1,3:2,5:3,10:4`                             |
+| Sub-bass 20–50 Hz (bass amp, subway, big HVAC)           | `HOBA_BUCKETS=20:1,30:2,40:3,50:4` `HOBA_SNR=10`            |
+| Audible-test 1–2.5 kHz (CI / live demos)                 | `HOBA_BUCKETS=1000:1,1500:2,2000:3,2500:4`                  |
 
 The `audible-test` cargo feature still exists as a convenience preset that
-flips the compile-time default to 1–2.5 kHz. It is no longer the only path to
-non-infrasound operation — env vars do the same thing on a release binary.
-
-> Restoring the historical 19–21 kHz ultrasonic band: `HOBA_BUCKETS=19000:1,19500:2,20000:3,20500:4`. Available for parity with v0.3.0 deployments; not a recommended default.
+flips the compile-time default to 1–2.5 kHz. It is no longer the only path
+to non-infrasound operation — env vars do the same thing on a release binary.
 
 ## Demo
 
@@ -151,19 +168,29 @@ collapses into a flood of BABEL.
 
 Microphone and speaker frequency response varies per device. Before
 relying on the trigger, check whether your mic actually picks up the
-target band loudly enough:
+target band loudly enough — i.e. with enough SNR over the local noise
+floor for the production detector to fire:
 
 ```bash
 hoba check                            # default 19/19.5/20/20.5 kHz, 5 s each
 hoba check --list-devices             # enumerate cpal inputs/outputs
 hoba check --bands 100,200,300        # arbitrary bands, no recompile
 hoba check --bands 19000:1,19500:2    # explicit (hz:depth) pairs
-hoba check --threshold 1000           # override the raw-power threshold
+hoba check --snr 10                   # tighten the SNR threshold to 10 dB
+hoba check --threshold 10             # deprecated alias for --snr (still dB)
 ```
 
-`hoba check` plays a sine on each band, measures the median peak at the
-mic, and prints a per-band PASS/FAIL plus an overall verdict. Exit code
-is `0` only when every band passes.
+`hoba check` plays a sine on each band, measures the median peak and the
+median noise floor at the mic, and prints a per-band table:
+
+```text
+band  target_hz  detected_hz  peak_db    noise_db    snr_db   verdict
+   1     150.0      149.8     -44.9 dB   -88.4 dB   43.5 dB  PASS
+```
+
+A band PASSes when `snr_db ≥ snr_threshold_db` (default 6 dB, same as
+`DetectorConfig::snr_threshold_db`). Exit code is `0` only when every band
+passes.
 
 The `check` subcommand defaults to the historical 19–21 kHz sweep because
 that's a band consumer speakers actually try to reproduce, even badly. The

--- a/README.md
+++ b/README.md
@@ -9,11 +9,34 @@ when you do not need the full surface of `rand`.
 <!-- Demo recording goes here. -->
 <!-- ![hoba demo](docs/demo.gif) -->
 
+## Why infrasound is the default
+
+Starting with v0.4.0, the release default of `hoba`'s environmental quality
+monitor watches **infrasound — 1, 3, 5, and 10 Hz**, all well below the human
+audibility floor (~20 Hz). The reasoning is deliberate.
+
+In *Patlabor: The Movie* (1989), the HOS / バビロンプロジェクト triggers
+through low-frequency wind resonance against tall buildings — never a sound a
+person can hear, never something you could play through a speaker. `hoba`'s
+release default takes that literally: 1 / 3 / 5 / 10 Hz are physically below
+what any consumer playback chain reproduces. A laptop will not trigger this
+default by accident; a phone will not; a YouTube video will not. The only
+sources that reliably reach these frequencies are real environmental events —
+**earthquakes, typhoon gusts, large industrial machinery, big HVAC plants,
+subway trains rolling past**. That "doesn't fire in everyday life" is the
+whole point. The default is supposed to fire on the day you have already
+forgotten you ever depended on `hoba`.
+
+If you actually want a band you can demo through speakers, you have two
+options without recompiling: the `audible-test` cargo feature (1–2.5 kHz), or
+`HOBA_BUCKETS` to point the detector anywhere your hardware can reach. See
+[Configuration](#configuration).
+
 ## Quickstart
 
 ```toml
 [dependencies]
-hoba = "0.1"
+hoba = "0.4"
 ```
 
 ```rust
@@ -45,7 +68,7 @@ To opt out of the monitor entirely:
 
 ```toml
 [dependencies]
-hoba = { version = "0.1", default-features = false }
+hoba = { version = "0.4", default-features = false }
 ```
 
 ## Configuration
@@ -58,18 +81,23 @@ The detector ships with two presets and accepts arbitrary runtime overrides
 ```rust
 use hoba::audio::{Detector, DetectorConfig, MicSource};
 
-// Production default (19–21 kHz, threshold 10_000) — equivalent to Detector::new().
+// Production default: infrasound 1 / 3 / 5 / 10 Hz, threshold 10_000.
+// Will not fire on consumer audio — by design.
 let cfg = DetectorConfig::release_default();
 
-// Audible-band preset, reachable from a release build (no `audible-test` feature needed).
+// Audible-band preset, reachable from a release build (no `audible-test`
+// feature needed). Use this for development, CI, and live demos.
 let cfg = DetectorConfig::audible_test();
 
 // Custom: sub-bass HVAC monitor, 20–50 Hz, lower power threshold.
+// Reachable through a bass amp / subwoofer.
 let cfg = DetectorConfig {
     buckets: vec![(20.0, 1), (30.0, 2), (40.0, 3), (50.0, 4)],
     power_threshold: 1_000.0,
     peak_band_hz: (10.0, 60.0),
     sample_rate: 48_000,
+    fft_size: 8192,
+    bucket_half_width_hz: 5.0,
 };
 
 let detector = Detector::with_config(MicSource::new(), cfg);
@@ -91,26 +119,33 @@ them on stderr.
 
 ### Picking a band
 
-| Use case                                    | Suggested config                                     |
-| ------------------------------------------- | ---------------------------------------------------- |
-| Sub-bass 20–50 Hz (bass amp, HVAC, subway)  | `HOBA_BUCKETS=20:1,30:2,40:3,50:4`                   |
-| Ultrasonic 19–21 kHz (default, piezo, mice) | leave unset — release default                        |
-| Audible-test 1–2.5 kHz (CI / live demos)    | `HOBA_BUCKETS=1000:1,1500:2,2000:3,2500:4` `HOBA_THRESHOLD=100` |
+| Use case                                               | Suggested config                                                  |
+| ------------------------------------------------------ | ----------------------------------------------------------------- |
+| Infrasound 1–10 Hz (default — earthquake, HVAC, gusts) | leave unset — release default                                     |
+| Sub-bass 20–50 Hz (bass amp, subway, big HVAC)         | `HOBA_BUCKETS=20:1,30:2,40:3,50:4` `HOBA_THRESHOLD=1000`          |
+| Audible-test 1–2.5 kHz (CI / live demos)               | `HOBA_BUCKETS=1000:1,1500:2,2000:3,2500:4` `HOBA_THRESHOLD=100`   |
 
 The `audible-test` cargo feature still exists as a convenience preset that
-flips the compile-time default. It is no longer the only path to non-ultrasonic
-operation — env vars do the same thing on a release binary.
+flips the compile-time default to 1–2.5 kHz. It is no longer the only path to
+non-infrasound operation — env vars do the same thing on a release binary.
+
+> Restoring the historical 19–21 kHz ultrasonic band: `HOBA_BUCKETS=19000:1,19500:2,20000:3,20500:4`. Available for parity with v0.3.0 deployments; not a recommended default.
 
 ## Demo
 
 A live demo is included:
 
 ```bash
-cargo run --example demo
+# Audible-band demo — the recommended way to see it react to a tone.
+cargo run --example babel --features audible-test
+
+# Or against the infrasound release default (will sit quietly until
+# something seismic actually happens):
+cargo run --example babel
 ```
 
-It prints a `randint(1, 6)` once per second alongside the current
-detector state. Try the demo while playing different ambient sounds.
+It prints scripture line by line; while the detector is compromised, the feed
+collapses into a flood of BABEL.
 
 ## Self-test your device
 
@@ -129,6 +164,11 @@ hoba check --threshold 1000           # override the raw-power threshold
 `hoba check` plays a sine on each band, measures the median peak at the
 mic, and prints a per-band PASS/FAIL plus an overall verdict. Exit code
 is `0` only when every band passes.
+
+The `check` subcommand defaults to the historical 19–21 kHz sweep because
+that's a band consumer speakers actually try to reproduce, even badly. The
+release-default infrasound band cannot meaningfully be self-tested with
+ordinary hardware — that is the design.
 
 Three common scenarios:
 
@@ -159,11 +199,11 @@ Full API on [docs.rs/hoba](https://docs.rs/hoba).
 
 ## Inspired by
 
-The name and the spirit are taken from *Hoba Eiichi* (帆場暎一), in tribute
-to a fictional programmer whose code only revealed its true behavior under
-the right conditions. The environment monitor itself is a small homage to
-the Famicom 2P controller microphone — a hidden input channel a few games
-quietly used as a secret.
+The name and the spirit are taken from *Hoba Eiichi* (帆場暎一), the
+fictional programmer in *Patlabor: The Movie* (1989) whose code only
+revealed its true behaviour under the right conditions. The release
+default's infrasound band is a direct nod to HOS / バビロンプロジェクト —
+something that does not fire in everyday life, and is not supposed to.
 
 ## License
 

--- a/examples/babel.rs
+++ b/examples/babel.rs
@@ -1,35 +1,51 @@
 //! Patlabor-flavored demo: streams scripture line by line; while the
 //! detector is compromised, the feed collapses into a flood of BABEL.
 //!
-//! Run:
+//! Run (recommended for live demos):
 //!
 //! ```text
 //! cargo run --example babel --features audible-test
 //! ```
 //!
-//! By default the demo emits the trigger tone from the default output
-//! device, the mic loops it back, and the detector flips. Pass `--listen`
-//! to disable emission and use an external tone source instead.
+//! With `--features audible-test` the trigger sits at 1 kHz; the demo
+//! emits that from the default output device, the mic loops it back, and
+//! the detector flips. Pass `--listen` to disable emission and use an
+//! external tone source instead.
+//!
+//! Without `--features audible-test`, the detector watches the **release
+//! default** infrasound band (1 / 3 / 5 / 10 Hz). No consumer speaker can
+//! reproduce that, by design — see `DetectorConfig::release_default` for
+//! the rationale. The example will start, print scripture, and quietly
+//! wait. To actually trigger it you need real environmental infrasound
+//! (earthquake, typhoon gust, large HVAC, subway) or to override the band
+//! via `HOBA_BUCKETS` / the `--bands` flag.
 //!
 //! A diagnostic line on stderr shows what the detector is observing:
 //! `[depth=N peak=AAA Hz BB.B dB]`. If `peak_db` stays near silence
 //! (-90 dB or lower) while `--emit` is on, the speaker → mic loopback is
 //! broken (output muted, mic missing/permission denied, BlueTooth headset
 //! splitting in/out, etc.).
-//!
-//! Without `--features audible-test` the trigger sits at 19 kHz, which
-//! most consumer speakers cannot reproduce — use the audible band for
-//! live demos.
 
 use std::io::Write;
 use std::time::{Duration, Instant};
 
 use hoba::audio::{AudioSource, Detector, DetectorConfig, MicSource};
 
+/// Compile-time hint for `--emit`: the lowest bucket center in the active
+/// preset. Under `audible-test` the example can actually loop this back
+/// through speakers; under the release default (infrasound) it is well
+/// below what cpal will play meaningfully, and emission is forced off
+/// unless the user explicitly supplies their own `--bands`.
 #[cfg(feature = "audible-test")]
 const TRIGGER_HZ: f32 = 1_000.0;
 #[cfg(not(feature = "audible-test"))]
-const TRIGGER_HZ: f32 = 19_000.0;
+const TRIGGER_HZ: f32 = 1.0;
+/// True when the compile-time default trigger band is something a consumer
+/// speaker can actually reproduce. Off for the infrasound release default.
+#[cfg(feature = "audible-test")]
+const DEFAULT_BAND_PLAYABLE: bool = true;
+#[cfg(not(feature = "audible-test"))]
+const DEFAULT_BAND_PLAYABLE: bool = false;
 
 /// Parses `--bands "<hz>:<depth>,..."` into a `Vec<(f32, u8)>`. Each item must
 /// carry an explicit depth (1..=4). Whitespace tolerated; empty list rejected.
@@ -111,7 +127,17 @@ fn main() {
         list_devices();
         return;
     }
-    let emit_enabled = !args.iter().any(|a| a == "--listen" || a == "--no-emit");
+    // Emission policy: `--listen` / `--no-emit` always wins. Otherwise emit
+    // when (a) the user explicitly supplied `--bands` (they know the band is
+    // playable), or (b) the compile-time default band is itself playable
+    // (audible-test feature). Under the infrasound release default with no
+    // `--bands`, there is nothing meaningful to emit; the demo runs in
+    // listen-only mode and waits for real environmental infrasound.
+    let listen_flag = args.iter().any(|a| a == "--listen" || a == "--no-emit");
+    let bands_flag_present = args
+        .iter()
+        .any(|a| a == "--bands" || a.starts_with("--bands="));
+    let emit_enabled = !listen_flag && (bands_flag_present || DEFAULT_BAND_PLAYABLE);
 
     // Optional CLI overrides for the detector. Falling back to the compile-time
     // default keeps the existing Patlabor demo behaviour untouched when neither
@@ -136,6 +162,16 @@ fn main() {
         },
         None => None,
     };
+
+    if !DEFAULT_BAND_PLAYABLE && !bands_flag_present {
+        eprintln!(
+            "(release default: infrasound 1–10 Hz. No consumer speaker can play this; \
+the demo will sit quietly until your office HVAC kicks in or a typhoon \
+strolls past. Use --features audible-test for a 1 kHz loopback demo, or \
+--bands <hz>:<depth>,... to point the detector somewhere your hardware can \
+actually reach.)"
+        );
+    }
 
     let mic = MicSource::new();
     if mic.is_active() {

--- a/examples/babel.rs
+++ b/examples/babel.rs
@@ -157,16 +157,21 @@ fn main() {
         },
         None => None,
     };
-    let threshold_override = match parse_value_arg(&args, "--threshold") {
-        Some(s) => match s.trim().parse::<f32>() {
-            Ok(v) if v.is_finite() && v >= 0.0 => Some(v),
-            _ => {
-                eprintln!("--threshold: must be non-negative and finite, got {s:?}");
-                std::process::exit(2);
-            }
-        },
-        None => None,
-    };
+    // Demo accepts either flag spelling for the SNR threshold (in dB) since
+    // v0.4.0; `--threshold` is the deprecated alias for `--snr`. Either way
+    // the value is interpreted as a dB SNR — no longer the v0.3.x raw-power
+    // knob.
+    let snr_override =
+        match parse_value_arg(&args, "--snr").or_else(|| parse_value_arg(&args, "--threshold")) {
+            Some(s) => match s.trim().parse::<f32>() {
+                Ok(v) if v.is_finite() && v >= 0.0 => Some(v),
+                _ => {
+                    eprintln!("--snr: must be non-negative and finite (dB), got {s:?}");
+                    std::process::exit(2);
+                }
+            },
+            None => None,
+        };
 
     if !DEFAULT_BAND_PLAYABLE && !bands_flag_present {
         eprintln!(
@@ -217,18 +222,18 @@ detector somewhere your hardware can actually reach.)"
 
     // Build the detector. If neither override was supplied, use the compile-time
     // default; otherwise start from the default and patch in the user's values.
-    let mut detector = if bands_override.is_some() || threshold_override.is_some() {
+    let mut detector = if bands_override.is_some() || snr_override.is_some() {
         let mut cfg = DetectorConfig::default();
         if let Some(buckets) = bands_override {
             cfg.peak_band_hz = DetectorConfig::peak_band_from_buckets(&buckets);
             cfg.buckets = buckets;
         }
-        if let Some(t) = threshold_override {
-            cfg.power_threshold = t;
+        if let Some(t) = snr_override {
+            cfg.snr_threshold_db = t;
         }
         eprintln!(
-            "(detector: buckets={:?} threshold={} peak_band={:?})",
-            cfg.buckets, cfg.power_threshold, cfg.peak_band_hz
+            "(detector: buckets={:?} snr_threshold_db={} peak_band={:?})",
+            cfg.buckets, cfg.snr_threshold_db, cfg.peak_band_hz
         );
         Detector::with_config(mic, cfg)
     } else {
@@ -245,10 +250,12 @@ detector somewhere your hardware can actually reach.)"
 
         if now >= next_heartbeat {
             eprintln!(
-                "[depth={} peak={:>5.0} Hz {:>5.1} dB]",
+                "[depth={} peak={:>5.0} Hz {:>5.1} dB | noise {:>5.1} dB | snr {:>4.1} dB]",
                 depth,
                 detector.peak_hz(),
-                detector.peak_db()
+                detector.peak_db(),
+                detector.noise_floor_db(),
+                detector.snr_db()
             );
             next_heartbeat = now + HEARTBEAT_CADENCE;
         }

--- a/examples/babel.rs
+++ b/examples/babel.rs
@@ -13,12 +13,14 @@
 //! external tone source instead.
 //!
 //! Without `--features audible-test`, the detector watches the **release
-//! default** infrasound band (1 / 3 / 5 / 10 Hz). No consumer speaker can
-//! reproduce that, by design — see `DetectorConfig::release_default` for
-//! the rationale. The example will start, print scripture, and quietly
-//! wait. To actually trigger it you need real environmental infrasound
-//! (earthquake, typhoon gust, large HVAC, subway) or to override the band
-//! via `HOBA_BUCKETS` / the `--bands` flag.
+//! default** infrasound band — a single 1–10 Hz bucket that fires at depth
+//! 4 anywhere in the window (no graded depth, matching the Patlabor HOS).
+//! No consumer speaker can reproduce that, by design — see
+//! `DetectorConfig::release_default` for the rationale. The example will
+//! start, print scripture, and quietly wait. To actually trigger it you
+//! need real environmental infrasound (earthquake, typhoon gust, large
+//! HVAC, subway) or to override the band via `HOBA_BUCKETS` / the
+//! `--bands` flag.
 //!
 //! A diagnostic line on stderr shows what the detector is observing:
 //! `[depth=N peak=AAA Hz BB.B dB]`. If `peak_db` stays near silence
@@ -38,8 +40,11 @@ use hoba::audio::{AudioSource, Detector, DetectorConfig, MicSource};
 /// unless the user explicitly supplies their own `--bands`.
 #[cfg(feature = "audible-test")]
 const TRIGGER_HZ: f32 = 1_000.0;
+/// Centre of the single 1–10 Hz infrasound bucket under the release
+/// default. Used as the `--emit` fallback frequency, but cpal cannot
+/// meaningfully play it — the demo forces listen-only mode below.
 #[cfg(not(feature = "audible-test"))]
-const TRIGGER_HZ: f32 = 1.0;
+const TRIGGER_HZ: f32 = 5.5;
 /// True when the compile-time default trigger band is something a consumer
 /// speaker can actually reproduce. Off for the infrasound release default.
 #[cfg(feature = "audible-test")]
@@ -165,11 +170,11 @@ fn main() {
 
     if !DEFAULT_BAND_PLAYABLE && !bands_flag_present {
         eprintln!(
-            "(release default: infrasound 1–10 Hz. No consumer speaker can play this; \
-the demo will sit quietly until your office HVAC kicks in or a typhoon \
-strolls past. Use --features audible-test for a 1 kHz loopback demo, or \
---bands <hz>:<depth>,... to point the detector somewhere your hardware can \
-actually reach.)"
+            "(release default: a single 1–10 Hz infrasound bucket, depth 4. \
+No consumer speaker can play this; the demo will sit quietly until your \
+office HVAC kicks in or a typhoon strolls past. Use --features audible-test \
+for a 1 kHz loopback demo, or --bands <hz>:<depth>,... to point the \
+detector somewhere your hardware can actually reach.)"
         );
     }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -116,6 +116,12 @@ const DEFAULT_BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
 /// (peak magnitude is zero). Callers comparing against silence should use
 /// this constant rather than the literal.
 pub const SILENCE_DB: f32 = -100.0;
+/// Default `snr_threshold_db` for both presets and any caller that does not
+/// set it explicitly. 6 dB ≈ 2× amplitude over the noise floor — the same
+/// rule of thumb radio engineering uses to call something "audible at all".
+/// Empirically separates real triggers from quiet-room background hum on
+/// every device the maintainer has tested.
+pub const DEFAULT_SNR_THRESHOLD_DB: f32 = 6.0;
 /// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
 const STREAK_TO_FLIP: u32 = 3;
 /// Internal sample rate the audible-test config is calibrated against. Detector logic
@@ -142,9 +148,16 @@ const INFRASOUND_SAMPLE_RATE: u32 = 44_100;
 ///   count reported when that bucket dominates. Empty `buckets` makes the
 ///   detector unable to trigger; the constructor accepts it but the resulting
 ///   detector permanently reports `depth() == 0`.
-/// - `power_threshold`: minimum raw band power (post-FFT) for the dominant
-///   bucket to count. Same units as the legacy const.
-/// - `peak_band_hz`: `(lo, hi)` window scanned for `peak_hz` / `peak_db`. Use
+/// - `snr_threshold_db`: minimum signal-to-noise ratio (in dB) the bucket's
+///   peak must beat over the surrounding noise floor before that bucket
+///   counts as triggered. Replaces the v0.3.x raw `power_threshold`: SNR is
+///   what "is there a frequency in this band" actually means once you stop
+///   relying on a hand-calibrated absolute amplitude. The default is 6 dB —
+///   2× signal over noise floor, the same threshold radio engineering uses
+///   to call something "audible at all".
+/// - `peak_band_hz`: `(lo, hi)` window scanned for `peak_hz` / `peak_db`,
+///   AND for the per-poll noise-floor estimate (median bin power across the
+///   band, excluding each bucket's window). Use
 ///   [`DetectorConfig::peak_band_from_buckets`] to derive a sensible default
 ///   covering all bucket centers plus margin.
 /// - `sample_rate`: documentation hint only; the live source's reported rate
@@ -153,23 +166,31 @@ const INFRASOUND_SAMPLE_RATE: u32 = 44_100;
 pub struct DetectorConfig {
     /// `(center_hz, depth)` pairs that define the trigger buckets.
     pub buckets: Vec<(f32, u8)>,
-    /// Minimum raw band power required for the dominant bucket to flip the trigger.
-    pub power_threshold: f32,
-    /// `(lo, hi)` Hz bounds for the peak-search band reported via `peak_hz` / `peak_db`.
+    /// Minimum signal-to-noise ratio in dB the bucket peak must beat over the
+    /// noise floor (median bin power inside `peak_band_hz`, excluding each
+    /// bucket's own window) before the bucket counts as triggered.
+    ///
+    /// 6 dB (≈ 2× amplitude) is the v0.4.0 default and the same threshold
+    /// radio engineering uses for "audible at all". Push to 10–12 dB if the
+    /// host environment has a noisy room tone you want to distinguish from
+    /// real triggers; drop to 3 dB if you specifically want a hair-trigger.
+    pub snr_threshold_db: f32,
+    /// `(lo, hi)` Hz bounds for the peak-search band reported via `peak_hz` /
+    /// `peak_db`, and the band the noise-floor estimate is taken from.
     pub peak_band_hz: (f32, f32),
     /// Documentation hint — the live source dictates actual FFT bin width.
     pub sample_rate: u32,
     /// FFT window length in samples. Larger = finer Hz resolution at the cost
     /// of latency and per-poll work. The infrasound release default uses 65536
-    /// (~1.4 s at 48 kHz) so 1 / 3 / 5 / 10 Hz buckets are separable; the
+    /// (~1.4 s at 48 kHz) so the 1 Hz end of the band is resolvable; the
     /// audible-test preset stays at 2048 since 23 Hz bin width is plenty for
     /// 1–2.5 kHz tones. Must be a power of two for `rustfft` planner efficiency,
     /// though the planner accepts other sizes.
     pub fft_size: usize,
     /// Half-width of each bucket window in Hz; band power for a bucket is
-    /// summed over `center ± this`. Tighten for closely-spaced buckets
-    /// (infrasound default uses 1.0 so 1 vs 3 Hz buckets stay distinct);
-    /// widen when the source has poor frequency stability.
+    /// summed over `center ± this`. The infrasound default uses 4.5 Hz so a
+    /// single bucket centred on 5.5 Hz spans the entire 1–10 Hz trigger
+    /// window; widen further when the source has poor frequency stability.
     pub bucket_half_width_hz: f32,
 }
 
@@ -192,10 +213,13 @@ impl DetectorConfig {
     ///
     /// The 65536-sample FFT window (~1.4 s at 48 kHz) gives ~0.73 Hz bin
     /// resolution, fine enough to resolve the 1 Hz end of the band against
-    /// rectangular-window leakage. The threshold is the same 10_000 used by
-    /// the previous graded-depth design — re-tuning it would have changed the
-    /// trigger sensitivity, which is orthogonal to the binary-vs-graded
-    /// question this default is settling.
+    /// rectangular-window leakage.
+    ///
+    /// **Trigger criterion** (since v0.4.0): the bucket peak must beat the
+    /// surrounding noise floor by at least `snr_threshold_db` (default 6 dB).
+    /// The hand-calibrated absolute `power_threshold` from v0.3.x is gone —
+    /// SNR is what "a frequency is present in this band" actually means once
+    /// you stop pretending mic gain and room tone are constant across hosts.
     ///
     /// Callers who explicitly want graded buckets (e.g. the historical
     /// 1 / 3 / 5 / 10 Hz tiers) or a different band (sub-bass HVAC, audible
@@ -203,13 +227,13 @@ impl DetectorConfig {
     /// [`Detector::with_config`]:
     ///
     /// ```text
-    /// HOBA_BUCKETS=1:1,3:2,5:3,10:4   # restore graded depth
-    /// HOBA_BUCKETS=20:1,30:2,40:3,50:4 HOBA_THRESHOLD=1000   # sub-bass HVAC
+    /// HOBA_BUCKETS=1:1,3:2,5:3,10:4         # restore graded depth
+    /// HOBA_BUCKETS=20:1,30:2,40:3,50:4 HOBA_SNR=10   # sub-bass HVAC, stricter SNR
     /// ```
     pub fn release_default() -> Self {
         Self {
             buckets: vec![(5.5, 4)],
-            power_threshold: 10_000.0,
+            snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
             peak_band_hz: (0.5, 12.0),
             sample_rate: INFRASOUND_SAMPLE_RATE,
             fft_size: RELEASE_FFT_SIZE,
@@ -223,7 +247,7 @@ impl DetectorConfig {
     pub fn audible_test() -> Self {
         Self {
             buckets: vec![(1_000.0, 1), (1_500.0, 2), (2_000.0, 3), (2_500.0, 4)],
-            power_threshold: 100.0,
+            snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
             peak_band_hz: (900.0, 2_600.0),
             sample_rate: DEFAULT_SAMPLE_RATE,
             fft_size: DEFAULT_FFT_SIZE,
@@ -231,9 +255,16 @@ impl DetectorConfig {
         }
     }
 
-    /// Reads `HOBA_BUCKETS` / `HOBA_THRESHOLD` / `HOBA_PEAK_BAND` from the
-    /// process environment and merges them with [`Self::release_default`] (or
+    /// Reads `HOBA_BUCKETS` / `HOBA_SNR` / `HOBA_PEAK_BAND` from the process
+    /// environment and merges them with [`Self::release_default`] (or
     /// [`Self::audible_test`] when the `audible-test` feature is on).
+    ///
+    /// `HOBA_THRESHOLD` (the v0.3.x raw-power threshold) is still inspected
+    /// for back-compat detection but its value is **ignored** — the unit
+    /// changed from raw post-FFT power to a dB SNR, and silently
+    /// reinterpreting the number would produce surprising trigger behaviour.
+    /// Set `HOBA_DEBUG=1` to see a one-line deprecation note on stderr; use
+    /// `HOBA_SNR` instead.
     ///
     /// Returns `None` if no relevant env vars are set, so callers can skip
     /// the override path entirely. Returns `Some(config)` if at least one
@@ -243,9 +274,14 @@ impl DetectorConfig {
     /// hoba's library-fails-quietly contract).
     pub fn from_env() -> Option<Self> {
         let buckets_raw = std::env::var("HOBA_BUCKETS").ok();
-        let threshold_raw = std::env::var("HOBA_THRESHOLD").ok();
+        let snr_raw = std::env::var("HOBA_SNR").ok();
+        let legacy_threshold_raw = std::env::var("HOBA_THRESHOLD").ok();
         let peak_band_raw = std::env::var("HOBA_PEAK_BAND").ok();
-        if buckets_raw.is_none() && threshold_raw.is_none() && peak_band_raw.is_none() {
+        if buckets_raw.is_none()
+            && snr_raw.is_none()
+            && legacy_threshold_raw.is_none()
+            && peak_band_raw.is_none()
+        {
             return None;
         }
 
@@ -277,15 +313,22 @@ impl DetectorConfig {
             }
         }
 
-        if let Some(s) = threshold_raw.as_deref() {
+        if let Some(s) = snr_raw.as_deref() {
             match s.trim().parse::<f32>() {
-                Ok(v) if v.is_finite() && v >= 0.0 => config.power_threshold = v,
+                Ok(v) if v.is_finite() && v >= 0.0 => config.snr_threshold_db = v,
                 Ok(_) | Err(_) => {
                     if debug {
-                        eprintln!("hoba: HOBA_THRESHOLD invalid ({s:?}); using default");
+                        eprintln!("hoba: HOBA_SNR invalid ({s:?}); using default");
                     }
                 }
             }
+        }
+
+        if legacy_threshold_raw.is_some() && debug {
+            eprintln!(
+                "hoba: HOBA_THRESHOLD is deprecated since v0.4.0 (raw-power threshold replaced \
+                 by dB SNR); ignoring. Use HOBA_SNR=<dB> instead."
+            );
         }
 
         if let Some(s) = peak_band_raw.as_deref() {
@@ -412,6 +455,7 @@ pub struct Detector<S: AudioSource> {
     depth: u8,
     last_peak_hz: f32,
     last_peak_db: f32,
+    last_noise_floor_db: f32,
     config: DetectorConfig,
 }
 
@@ -459,6 +503,7 @@ impl<S: AudioSource> Detector<S> {
             depth: 0,
             last_peak_hz: 0.0,
             last_peak_db: SILENCE_DB,
+            last_noise_floor_db: SILENCE_DB,
             config,
         }
     }
@@ -496,15 +541,19 @@ impl<S: AudioSource> Detector<S> {
         let (peak_bin, peak_norm_sqr) = self.peak_in_band(peak_lo, peak_hi);
         let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
         self.last_peak_hz = (peak_bin as f64 * bin_hz) as f32;
-        let peak_magnitude = peak_norm_sqr.sqrt();
         let max_magnitude = (fft_size / 2) as f32;
-        self.last_peak_db = if peak_magnitude > 0.0 {
-            20.0 * (peak_magnitude / max_magnitude).log10()
-        } else {
-            SILENCE_DB
-        };
+        self.last_peak_db = power_to_db(peak_norm_sqr, max_magnitude);
 
-        match self.dominant_bucket() {
+        // Estimate the noise floor as the median bin *power* (norm_sqr) inside
+        // peak_band_hz, excluding each bucket's own window so a strong tone
+        // sitting inside a bucket can never inflate its own floor and
+        // self-mask. Power-domain median first, dB conversion afterwards: a
+        // dB-domain median would over-weight near-silent bins (-100 dB
+        // outliers pull a dB median harder than they pull a power median).
+        let noise_floor_power = self.noise_floor_power(peak_lo, peak_hi);
+        self.last_noise_floor_db = power_to_db(noise_floor_power, max_magnitude);
+
+        match self.dominant_bucket(noise_floor_power, max_magnitude) {
             Some(depth) => {
                 self.high_streak = self.high_streak.saturating_add(1);
                 self.low_streak = 0;
@@ -546,6 +595,23 @@ impl<S: AudioSource> Detector<S> {
         self.last_peak_db
     }
 
+    /// dBFS magnitude of the noise-floor estimate (median bin power across
+    /// `peak_band_hz`, excluding each bucket's own window) from the most
+    /// recent [`poll`](Self::poll). Returns [`SILENCE_DB`] when the band
+    /// outside the buckets has no measurable energy or when `poll` has not
+    /// been called yet.
+    pub fn noise_floor_db(&self) -> f32 {
+        self.last_noise_floor_db
+    }
+
+    /// Signal-to-noise ratio in dB from the most recent
+    /// [`poll`](Self::poll), defined as `peak_db - noise_floor_db`. Returns
+    /// 0.0 before the first poll. Floors at 0.0 when peak is below the
+    /// floor — a negative SNR is information-free for trigger purposes.
+    pub fn snr_db(&self) -> f32 {
+        (self.last_peak_db - self.last_noise_floor_db).max(0.0)
+    }
+
     fn peak_in_band(&self, lo_hz: f32, hi_hz: f32) -> (usize, f32) {
         let fft_size = self.scratch.len();
         let nyquist_bin = fft_size / 2;
@@ -565,27 +631,55 @@ impl<S: AudioSource> Detector<S> {
         best
     }
 
-    fn dominant_bucket(&self) -> Option<u8> {
-        // Strict `>` keeps the first-listed (lower-depth) bucket on exact ties — clears
-        // fewer bits when the signal is ambiguous, which is the conservative default.
+    /// Returns the depth of the bucket whose peak best clears the SNR bar,
+    /// or `None` if no bucket beats the noise floor by at least
+    /// `snr_threshold_db`.
+    ///
+    /// Selection rule, in order: (1) drop any bucket whose `peak_db −
+    /// noise_floor_db` is below `snr_threshold_db`. (2) Among the
+    /// survivors, pick the bucket with the **strongest peak power** — the
+    /// loudest signal in the band. (3) On exact peak-power ties (rare in
+    /// practice; real audio is full of fractional bin energy) the
+    /// deepest-`depth` bucket wins.
+    ///
+    /// Why peak power and not max depth: under graded presets like
+    /// `audible_test` the buckets share a `peak_band_hz` window, so FFT
+    /// leakage from a real tone in one bucket dribbles into adjacent
+    /// buckets. A naïve "max-depth-among-firing" would let a 1 kHz tone
+    /// trigger the 2.5 kHz/depth-4 bucket from leakage alone. Picking the
+    /// strongest peak instead means the bucket actually receiving signal
+    /// energy is the one that fires, which is what users mean when they
+    /// configure graded buckets in the first place. Under the single-
+    /// bucket release default the rule collapses to "fire if SNR clears,"
+    /// matching the binary-trigger spirit of the *Patlabor* HOS.
+    fn dominant_bucket(&self, noise_floor_power: f32, max_magnitude: f32) -> Option<u8> {
         let half_width = self.config.bucket_half_width_hz;
+        let noise_floor_db = power_to_db(noise_floor_power, max_magnitude);
         let mut best: Option<(f32, u8)> = None;
         for &(center, depth) in &self.config.buckets {
-            let p = self.band_power_between(center - half_width, center + half_width);
-            if best.map_or(true, |(bp, _)| p > bp) {
-                best = Some((p, depth));
+            let peak_power = self.peak_power_between(center - half_width, center + half_width);
+            let peak_db = power_to_db(peak_power, max_magnitude);
+            let snr = peak_db - noise_floor_db;
+            if snr < self.config.snr_threshold_db {
+                continue;
+            }
+            let beats = match best {
+                None => true,
+                Some((bp, bd)) => peak_power > bp || (peak_power == bp && depth > bd),
+            };
+            if beats {
+                best = Some((peak_power, depth));
             }
         }
-        best.and_then(|(p, d)| {
-            if p >= self.config.power_threshold {
-                Some(d)
-            } else {
-                None
-            }
-        })
+        best.map(|(_, d)| d)
     }
 
-    fn band_power_between(&self, lo_hz: f32, hi_hz: f32) -> f32 {
+    /// Returns the strongest single-bin power inside `[lo_hz, hi_hz]`. Used
+    /// by [`Detector::dominant_bucket`] so a bucket's peak — not its summed
+    /// energy — is what gets compared to the noise floor. Summed-band power
+    /// would scale with bucket width and let a wide quiet bucket "beat" a
+    /// narrow loud one, which is the opposite of what SNR is asking.
+    fn peak_power_between(&self, lo_hz: f32, hi_hz: f32) -> f32 {
         let fft_size = self.scratch.len();
         let nyquist_bin = fft_size / 2;
         let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
@@ -594,10 +688,80 @@ impl<S: AudioSource> Detector<S> {
         if lo_bin > hi_bin {
             return 0.0;
         }
-        self.scratch[lo_bin..=hi_bin]
+        let mut best = 0.0f32;
+        for i in lo_bin..=hi_bin {
+            let p = self.scratch[i].norm_sqr();
+            if p > best {
+                best = p;
+            }
+        }
+        best
+    }
+
+    /// Median bin power inside `[lo_hz, hi_hz]`, excluding every bucket's
+    /// `center ± bucket_half_width_hz` window. Median rather than mean
+    /// because a single loud trigger tone would otherwise drag the floor up
+    /// linearly and mask itself; median is robust against that. Excluding
+    /// the bucket windows is essential — leaving them in lets a tone sitting
+    /// inside a bucket count toward "its own" noise floor.
+    fn noise_floor_power(&self, lo_hz: f32, hi_hz: f32) -> f32 {
+        let fft_size = self.scratch.len();
+        let nyquist_bin = fft_size / 2;
+        let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
+        let lo_bin = ((f64::from(lo_hz) / bin_hz).floor() as usize).min(nyquist_bin);
+        let hi_bin = ((f64::from(hi_hz) / bin_hz).ceil() as usize).min(nyquist_bin);
+        if lo_bin > hi_bin {
+            return 0.0;
+        }
+        let half_width = self.config.bucket_half_width_hz;
+        let mut excluded: Vec<(usize, usize)> = self
+            .config
+            .buckets
             .iter()
-            .map(|c| c.norm_sqr())
-            .sum()
+            .map(|&(center, _)| {
+                let blo = ((f64::from((center - half_width).max(0.0)) / bin_hz).floor() as usize)
+                    .min(nyquist_bin);
+                let bhi =
+                    ((f64::from(center + half_width) / bin_hz).ceil() as usize).min(nyquist_bin);
+                (blo, bhi)
+            })
+            .collect();
+        excluded.sort_unstable();
+
+        let mut out: Vec<f32> = Vec::with_capacity(hi_bin.saturating_sub(lo_bin) + 1);
+        for i in lo_bin..=hi_bin {
+            if excluded.iter().any(|&(blo, bhi)| i >= blo && i <= bhi) {
+                continue;
+            }
+            out.push(self.scratch[i].norm_sqr());
+        }
+        if out.is_empty() {
+            // Buckets cover the entire peak band — nothing left to estimate
+            // the floor from. Conservative fallback: pretend it is silent so
+            // SNR collapses to peak_db, which mirrors the v0.3.x behaviour
+            // and keeps the detector usable when the user explicitly tunes
+            // peak_band_hz tight to the buckets.
+            return 0.0;
+        }
+        out.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let n = out.len();
+        if n % 2 == 1 {
+            out[n / 2]
+        } else {
+            (out[n / 2 - 1] + out[n / 2]) * 0.5
+        }
+    }
+}
+
+/// Converts a single-bin / aggregated power value (FFT `norm_sqr`) into
+/// dBFS using the standard reference `max_magnitude = fft_size / 2`. Returns
+/// [`SILENCE_DB`] for non-positive input so callers never see `-inf` or NaN.
+fn power_to_db(power: f32, max_magnitude: f32) -> f32 {
+    if power > 0.0 {
+        let magnitude = power.sqrt();
+        20.0 * (magnitude / max_magnitude).log10()
+    } else {
+        SILENCE_DB
     }
 }
 
@@ -810,11 +974,13 @@ mod tests {
     /// `center_hz`, sized to match the historical 100 Hz half-width and a
     /// generous peak band so tone-injection tests stay deterministic. Uses
     /// the small 2048-point FFT window since the helper is only used for
-    /// kHz-scale tones in unit tests.
-    fn config_for_band(center_hz: f32, depth: u8, threshold: f32) -> DetectorConfig {
+    /// kHz-scale tones in unit tests. The third arg is the SNR threshold in
+    /// dB for the bucket (since v0.4.0 — replaces the v0.3.x raw power
+    /// threshold).
+    fn config_for_band(center_hz: f32, depth: u8, snr_threshold_db: f32) -> DetectorConfig {
         DetectorConfig {
             buckets: vec![(center_hz, depth)],
-            power_threshold: threshold,
+            snr_threshold_db,
             peak_band_hz: ((center_hz - 200.0).max(0.0), center_hz + 200.0),
             sample_rate: 48_000,
             fft_size: DEFAULT_FFT_SIZE,
@@ -825,7 +991,7 @@ mod tests {
     #[test]
     fn detector_with_config_triggers_on_custom_band() {
         // Pick a sub-bass band the const-based default would never see.
-        let cfg = config_for_band(200.0, 3, 100.0);
+        let cfg = config_for_band(200.0, 3, DEFAULT_SNR_THRESHOLD_DB);
         let mut detector = Detector::with_config(SineSource::new(200.0, 0.5), cfg);
         for _ in 0..12 {
             detector.poll();
@@ -837,12 +1003,133 @@ mod tests {
     #[test]
     fn detector_with_config_ignores_out_of_band_tone() {
         // 5 kHz tone, but the detector is configured to watch 200 Hz only.
-        let cfg = config_for_band(200.0, 1, 100.0);
+        let cfg = config_for_band(200.0, 1, DEFAULT_SNR_THRESHOLD_DB);
         let mut detector = Detector::with_config(SineSource::new(5_000.0, 0.5), cfg);
         for _ in 0..24 {
             detector.poll();
         }
         assert_eq!(detector.depth(), 0);
+    }
+
+    /// SNR sanity: a tone in the bucket should report a positive SNR well
+    /// above the default 6 dB threshold, while pure silence stays at 0.
+    /// This pins the noise-floor / SNR pipeline end-to-end without
+    /// reaching into private fields.
+    #[test]
+    fn detector_reports_snr_for_tone_and_silence() {
+        let cfg = config_for_band(200.0, 1, DEFAULT_SNR_THRESHOLD_DB);
+        let mut tone_det = Detector::with_config(SineSource::new(200.0, 0.5), cfg.clone());
+        for _ in 0..12 {
+            tone_det.poll();
+        }
+        assert!(
+            tone_det.snr_db() >= DEFAULT_SNR_THRESHOLD_DB,
+            "200 Hz tone should produce SNR ≥ {} dB, got {} dB (peak={:.1} floor={:.1})",
+            DEFAULT_SNR_THRESHOLD_DB,
+            tone_det.snr_db(),
+            tone_det.peak_db(),
+            tone_det.noise_floor_db()
+        );
+
+        let silence = ScriptedSource::new(vec![0.0f32; cfg.fft_size * 12], 48_000);
+        let mut sil_det = Detector::with_config(silence, cfg);
+        for _ in 0..12 {
+            sil_det.poll();
+        }
+        assert!(
+            sil_det.snr_db() < DEFAULT_SNR_THRESHOLD_DB,
+            "silence should not clear the SNR threshold (got {} dB)",
+            sil_det.snr_db()
+        );
+        assert_eq!(sil_det.depth(), 0);
+    }
+
+    /// Two-bucket selectivity: with two well-separated bucket centres in
+    /// the same `peak_band_hz`, injecting a tone at only one centre must
+    /// trigger only that bucket's depth — the other bucket's "peak" sits at
+    /// the noise floor and fails the SNR check. The 6 dB default makes this
+    /// trivially decidable for an amp-0.5 sine.
+    #[test]
+    fn detector_snr_selects_one_bucket_when_only_one_has_signal() {
+        // Buckets at 1 kHz (depth 1) and 2.5 kHz (depth 4); peak band wide
+        // enough to cover both with margin.
+        let cfg = DetectorConfig {
+            buckets: vec![(1_000.0, 1), (2_500.0, 4)],
+            snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
+            peak_band_hz: (500.0, 3_000.0),
+            sample_rate: 48_000,
+            fft_size: DEFAULT_FFT_SIZE,
+            bucket_half_width_hz: 50.0,
+        };
+        // Signal only at 1 kHz: only that bucket should fire (depth 1).
+        let mut det_low = Detector::with_config(SineSource::new(1_000.0, 0.5), cfg.clone());
+        for _ in 0..12 {
+            det_low.poll();
+        }
+        assert_eq!(
+            det_low.depth(),
+            1,
+            "tone at 1 kHz should fire bucket #1 only (depth 1), got {}",
+            det_low.depth()
+        );
+
+        // Signal only at 2.5 kHz: only the deeper bucket should fire.
+        let mut det_high = Detector::with_config(SineSource::new(2_500.0, 0.5), cfg);
+        for _ in 0..12 {
+            det_high.poll();
+        }
+        assert_eq!(
+            det_high.depth(),
+            4,
+            "tone at 2.5 kHz should fire bucket #2 only (depth 4), got {}",
+            det_high.depth()
+        );
+    }
+
+    /// SNR threshold gating: with a pathologically high `snr_threshold_db`
+    /// (e.g. 80 dB), even a clear in-band tone must fail to flip the
+    /// detector. Direct test that the SNR comparison actually gates depth
+    /// rather than getting bypassed by the streak counter.
+    #[test]
+    fn detector_high_snr_threshold_suppresses_trigger() {
+        let mut cfg = config_for_band(200.0, 3, 80.0);
+        cfg.fft_size = DEFAULT_FFT_SIZE;
+        let mut detector = Detector::with_config(SineSource::new(200.0, 0.5), cfg);
+        for _ in 0..24 {
+            detector.poll();
+        }
+        assert_eq!(
+            detector.depth(),
+            0,
+            "80 dB SNR requirement should suppress trigger (peak={:.1} floor={:.1} snr={:.1})",
+            detector.peak_db(),
+            detector.noise_floor_db(),
+            detector.snr_db()
+        );
+    }
+
+    /// Realistic baseline-amp data point from the maintainer's host:
+    /// an external 150 Hz tone (peak ≈ -45 dBFS) sitting on a quiet-room
+    /// floor (≈ -88 dBFS) should comfortably PASS at the default 6 dB SNR
+    /// threshold. Synthesised here via `peak_to_db`-equivalent power
+    /// math directly on the `power_to_db` helper, with no detector loop —
+    /// this is the unit-level guard for the README's worked example.
+    #[test]
+    fn power_to_db_round_trip_matches_amp_05_sine_calibration() {
+        // For an amp-0.5 sine in a 2048-point FFT, a single bin near the
+        // true frequency carries roughly (amp * fft_size / 4)^2 power. We
+        // do not need to reproduce the exact figure; what matters for the
+        // SNR contract is that `power_to_db` is monotonic and that a 100×
+        // power ratio equals the expected 20 dB.
+        let big = power_to_db(10_000.0, 1024.0);
+        let small = power_to_db(100.0, 1024.0);
+        let snr = big - small;
+        assert!(
+            (snr - 20.0).abs() < 0.001,
+            "100× power ratio should be 20 dB SNR, got {snr} dB"
+        );
+        // SILENCE_DB on zero-power input — guards the SNR floor.
+        assert!((power_to_db(0.0, 1024.0) - SILENCE_DB).abs() < 0.001);
     }
 
     #[test]
@@ -865,7 +1152,7 @@ mod tests {
             (hi - 10.0).abs() < 0.001,
             "hi edge of bucket should be 10.0 Hz"
         );
-        assert!((cfg.power_threshold - 10_000.0).abs() < 1.0);
+        assert!((cfg.snr_threshold_db - DEFAULT_SNR_THRESHOLD_DB).abs() < 0.001);
         assert_eq!(cfg.fft_size, RELEASE_FFT_SIZE);
         // Peak band must cover the bucket with margin on both sides.
         assert!(cfg.peak_band_hz.0 < 1.0);
@@ -877,7 +1164,7 @@ mod tests {
         let cfg = DetectorConfig::audible_test();
         assert_eq!(cfg.buckets.len(), 4);
         assert!((cfg.buckets[0].0 - 1_000.0).abs() < 1.0);
-        assert!((cfg.power_threshold - 100.0).abs() < 1.0);
+        assert!((cfg.snr_threshold_db - DEFAULT_SNR_THRESHOLD_DB).abs() < 0.001);
     }
 
     #[test]
@@ -907,27 +1194,27 @@ mod tests {
     }
 
     #[test]
-    fn detector_config_from_env_parses_threshold_only() {
+    fn detector_config_from_env_parses_snr_only() {
         let _g = EnvGuard::clear_all();
-        std::env::set_var("HOBA_THRESHOLD", "12345");
-        let cfg = DetectorConfig::from_env().expect("threshold override should yield Some");
-        assert!((cfg.power_threshold - 12_345.0).abs() < 1.0);
+        std::env::set_var("HOBA_SNR", "12.5");
+        let cfg = DetectorConfig::from_env().expect("snr override should yield Some");
+        assert!((cfg.snr_threshold_db - 12.5).abs() < 0.001);
         // Buckets fall back to the compile-time default.
         assert_eq!(cfg.buckets, base_default().buckets);
     }
 
     #[test]
-    fn detector_config_from_env_parses_buckets_and_threshold_and_peak_band() {
+    fn detector_config_from_env_parses_buckets_snr_and_peak_band() {
         let _g = EnvGuard::clear_all();
         std::env::set_var("HOBA_BUCKETS", "20:1,30:2,40:3,50:4");
-        std::env::set_var("HOBA_THRESHOLD", "8000.5");
+        std::env::set_var("HOBA_SNR", "9.0");
         std::env::set_var("HOBA_PEAK_BAND", "10:60");
         let cfg = DetectorConfig::from_env().expect("any override should yield Some");
         assert_eq!(
             cfg.buckets,
             vec![(20.0, 1), (30.0, 2), (40.0, 3), (50.0, 4)]
         );
-        assert!((cfg.power_threshold - 8_000.5).abs() < 0.001);
+        assert!((cfg.snr_threshold_db - 9.0).abs() < 0.001);
         assert_eq!(cfg.peak_band_hz, (10.0, 60.0));
     }
 
@@ -941,11 +1228,28 @@ mod tests {
     }
 
     #[test]
-    fn detector_config_from_env_falls_back_on_garbage_threshold() {
+    fn detector_config_from_env_falls_back_on_garbage_snr() {
         let _g = EnvGuard::clear_all();
-        std::env::set_var("HOBA_THRESHOLD", "not-a-number");
+        std::env::set_var("HOBA_SNR", "not-a-number");
         let cfg = DetectorConfig::from_env().expect("malformed override still yields Some");
-        assert!((cfg.power_threshold - base_default().power_threshold).abs() < 0.001);
+        assert!((cfg.snr_threshold_db - base_default().snr_threshold_db).abs() < 0.001);
+    }
+
+    #[test]
+    fn detector_config_from_env_legacy_threshold_yields_some_but_ignored() {
+        // HOBA_THRESHOLD is the v0.3.x raw-power knob. Since v0.4.0 the unit
+        // changed to dB SNR; reinterpreting the old number would silently
+        // change trigger behaviour, so we treat its presence as a triggering
+        // env var (returns Some) but ignore the value entirely.
+        let _g = EnvGuard::clear_all();
+        std::env::set_var("HOBA_THRESHOLD", "10000");
+        let cfg = DetectorConfig::from_env()
+            .expect("legacy threshold env var should still yield Some for back-compat detection");
+        assert!(
+            (cfg.snr_threshold_db - base_default().snr_threshold_db).abs() < 0.001,
+            "legacy HOBA_THRESHOLD must NOT bleed into snr_threshold_db (got {})",
+            cfg.snr_threshold_db
+        );
     }
 
     #[test]
@@ -961,7 +1265,7 @@ mod tests {
     /// so they're serialised through this guard plus a shared mutex in the
     /// helper itself (Rust runs unit tests in parallel by default).
     struct EnvGuard {
-        prior: [(String, Option<String>); 4],
+        prior: [(String, Option<String>); 5],
         _lock: std::sync::MutexGuard<'static, ()>,
     }
 
@@ -971,15 +1275,17 @@ mod tests {
             let lock = MUTEX.lock().unwrap_or_else(|p| p.into_inner());
             let names = [
                 "HOBA_BUCKETS",
+                "HOBA_SNR",
                 "HOBA_THRESHOLD",
                 "HOBA_PEAK_BAND",
                 "HOBA_DEBUG",
             ];
-            let mut prior: [(String, Option<String>); 4] = [
+            let mut prior: [(String, Option<String>); 5] = [
                 (names[0].into(), None),
                 (names[1].into(), None),
                 (names[2].into(), None),
                 (names[3].into(), None),
+                (names[4].into(), None),
             ];
             for (i, n) in names.iter().enumerate() {
                 prior[i] = ((*n).into(), std::env::var(n).ok());

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,8 +3,10 @@
 //! ```no_run
 //! use hoba::audio::{Detector, SineSource};
 //!
-//! // 19 kHz sits inside the production trigger band (19–21 kHz).
-//! let mut detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
+//! // 1 Hz sits inside the production trigger band (1–10 Hz infrasound).
+//! // Note: real consumer speakers cannot reproduce this — see
+//! // [`DetectorConfig::release_default`] for the rationale.
+//! let mut detector = Detector::with_source(SineSource::new(1.0, 0.5));
 //! for _ in 0..12 {
 //!     detector.poll();
 //! }
@@ -68,25 +70,38 @@ impl AudioSource for SineSource {
     }
 }
 
-/// 2048-point FFT: bin width 23.4 Hz at 48 kHz, ~810 cycles of a 19 kHz tone per window.
-const FFT_SIZE: usize = 2048;
+/// Default FFT window for the audible-test preset and any caller that does not
+/// override [`DetectorConfig::fft_size`]. 2048 samples = bin width 23.4 Hz at
+/// 48 kHz; comfortably resolves kHz-scale buckets.
+pub(crate) const DEFAULT_FFT_SIZE: usize = 2048;
+/// FFT window for the infrasound release default. 65536 samples ≈ 1.37 s at
+/// 48 kHz, giving a bin width of ~0.73 Hz — fine enough to discriminate the
+/// 1 / 3 / 5 / 10 Hz buckets even with rectangular-window leakage. Stepping
+/// down to 32768 collapses the 1 Hz and 3 Hz bins; stepping up to 131072
+/// doubles per-poll FFT cost without buying meaningful selectivity at the
+/// chosen bucket spacing.
+pub(crate) const RELEASE_FFT_SIZE: usize = 65536;
 /// Per-bucket center frequency (Hz) and corresponding mask depth (1–4 low bits cleared).
-/// Kept `pub(crate)` as a test fixture pinning the historical default band; live
-/// detection logic now reads from [`DetectorConfig`], so production code should
+/// Kept `pub(crate)` as a test fixture pinning the current default band; live
+/// detection logic reads from [`DetectorConfig`], so production code should
 /// reach the same values via [`DetectorConfig::release_default`] /
 /// [`DetectorConfig::audible_test`].
 #[cfg(not(feature = "audible-test"))]
 #[allow(dead_code)]
-pub(crate) const BUCKETS: [(f32, u8); 4] =
-    [(19_000.0, 1), (19_500.0, 2), (20_000.0, 3), (20_500.0, 4)];
+pub(crate) const BUCKETS: [(f32, u8); 4] = [(1.0, 1), (3.0, 2), (5.0, 3), (10.0, 4)];
 /// Audible-band stand-in for development. Most laptop and consumer speakers
 /// reproduce 1–2.5 kHz cleanly, so the detector can be exercised through a
 /// tone generator without specialized hardware.
 #[cfg(feature = "audible-test")]
 #[allow(dead_code)]
 pub(crate) const BUCKETS: [(f32, u8); 4] = [(1_000.0, 1), (1_500.0, 2), (2_000.0, 3), (2_500.0, 4)];
-/// Half-width of each bucket window in Hz; band power is summed over `center ± this`.
-const BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
+/// Default per-bucket half-width in Hz, used when a [`DetectorConfig`] does
+/// not specify [`DetectorConfig::bucket_half_width_hz`] and as the margin in
+/// [`DetectorConfig::peak_band_from_buckets`]. Sized for kHz-scale buckets
+/// (the audible-test preset and historical ultrasonic overrides); the
+/// infrasound release default narrows this to 1.0 Hz so 1 / 3 / 5 / 10 Hz
+/// buckets do not pollute each other.
+const DEFAULT_BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
 
 /// dBFS value reported by [`Detector::peak_db`] when no signal is present
 /// (peak magnitude is zero). Callers comparing against silence should use
@@ -94,10 +109,15 @@ const BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
 pub const SILENCE_DB: f32 = -100.0;
 /// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
 const STREAK_TO_FLIP: u32 = 3;
-/// Internal sample rate the default configs are calibrated against. Detector logic
+/// Internal sample rate the audible-test config is calibrated against. Detector logic
 /// recomputes bin sizes from the live source's reported sample rate, so this is
 /// only a documentation hint for env-var / CLI overrides.
 const DEFAULT_SAMPLE_RATE: u32 = 48_000;
+/// Sample rate hint for the infrasound release default. Most consumer mics
+/// run at 44.1 or 48 kHz; either is fine — what matters is the FFT window
+/// length in seconds, not the rate. 44.1 kHz makes the docs honest about
+/// which rate "civilian" devices typically deliver.
+const INFRASOUND_SAMPLE_RATE: u32 = 44_100;
 
 /// Runtime-tunable detector knobs.
 ///
@@ -130,16 +150,46 @@ pub struct DetectorConfig {
     pub peak_band_hz: (f32, f32),
     /// Documentation hint — the live source dictates actual FFT bin width.
     pub sample_rate: u32,
+    /// FFT window length in samples. Larger = finer Hz resolution at the cost
+    /// of latency and per-poll work. The infrasound release default uses 65536
+    /// (~1.4 s at 48 kHz) so 1 / 3 / 5 / 10 Hz buckets are separable; the
+    /// audible-test preset stays at 2048 since 23 Hz bin width is plenty for
+    /// 1–2.5 kHz tones. Must be a power of two for `rustfft` planner efficiency,
+    /// though the planner accepts other sizes.
+    pub fft_size: usize,
+    /// Half-width of each bucket window in Hz; band power for a bucket is
+    /// summed over `center ± this`. Tighten for closely-spaced buckets
+    /// (infrasound default uses 1.0 so 1 vs 3 Hz buckets stay distinct);
+    /// widen when the source has poor frequency stability.
+    pub bucket_half_width_hz: f32,
 }
 
 impl DetectorConfig {
-    /// Production default: 19–21 kHz ultrasonic band with the legacy 10_000 power threshold.
+    /// Production default: **infrasound 1 / 3 / 5 / 10 Hz**, all below the
+    /// human audibility floor (~20 Hz). Inspired by the HOS ("バビロンプロジェクト")
+    /// in *Patlabor: The Movie* (1989), which fires from low-frequency wind
+    /// resonance rather than anything speakers can play. A consumer playback
+    /// chain physically cannot trigger this default — the detector waits for
+    /// real environmental energy: earthquakes, typhoon gusts, heavy machinery,
+    /// large HVAC, subway passes. That "doesn't fire in everyday life" is the
+    /// whole point.
+    ///
+    /// Threshold and FFT window are sized together: the 65536-sample window
+    /// (~1.4 s at 48 kHz) gives ~0.73 Hz bin resolution, just fine enough to
+    /// keep the buckets distinct under rectangular-window leakage.
+    ///
+    /// Callers who explicitly want a different band (sub-bass HVAC, the old
+    /// ultrasonic 19–21 kHz placeholder, audible CI tones) can still get
+    /// there without a recompile via `HOBA_BUCKETS` or
+    /// [`Detector::with_config`].
     pub fn release_default() -> Self {
         Self {
-            buckets: vec![(19_000.0, 1), (19_500.0, 2), (20_000.0, 3), (20_500.0, 4)],
+            buckets: vec![(1.0, 1), (3.0, 2), (5.0, 3), (10.0, 4)],
             power_threshold: 10_000.0,
-            peak_band_hz: (18_900.0, 20_600.0),
-            sample_rate: DEFAULT_SAMPLE_RATE,
+            peak_band_hz: (0.5, 12.0),
+            sample_rate: INFRASOUND_SAMPLE_RATE,
+            fft_size: RELEASE_FFT_SIZE,
+            bucket_half_width_hz: 1.0,
         }
     }
 
@@ -152,6 +202,8 @@ impl DetectorConfig {
             power_threshold: 100.0,
             peak_band_hz: (900.0, 2_600.0),
             sample_rate: DEFAULT_SAMPLE_RATE,
+            fft_size: DEFAULT_FFT_SIZE,
+            bucket_half_width_hz: DEFAULT_BUCKET_HALF_WIDTH_HZ,
         }
     }
 
@@ -244,7 +296,7 @@ impl DetectorConfig {
                 hi = c;
             }
         }
-        let margin = BUCKET_HALF_WIDTH_HZ * 1.5;
+        let margin = DEFAULT_BUCKET_HALF_WIDTH_HZ * 1.5;
         ((lo - margin).max(0.0), hi + margin)
     }
 }
@@ -312,7 +364,8 @@ fn parse_peak_band_env(s: &str) -> Result<(f32, f32), String> {
     Ok((lo, hi))
 }
 
-/// Pulls samples from an [`AudioSource`] and detects ultrasonic trigger tones.
+/// Pulls samples from an [`AudioSource`] and detects trigger tones inside the
+/// configured bucket band.
 ///
 /// Note: `Debug` is hand-implemented because the boxed FFT trait object is
 /// not itself `Debug`. `Clone` is not implemented because the FFT planner
@@ -321,9 +374,10 @@ fn parse_peak_band_env(s: &str) -> Result<(f32, f32), String> {
 /// this.
 ///
 /// The trigger band is approximate. Rectangular-window leakage means tones
-/// just outside 19.0–20.5 kHz (within ~50 Hz) still flip the flag. For an
-/// "is the environment ultrasonic" check this is desirable; for narrowband
-/// classification, post-process the FFT separately.
+/// just outside the bucket centers (within roughly half the bin width) still
+/// flip the flag. For "is the environment in the trigger band" this is
+/// desirable; for narrowband classification, post-process the FFT
+/// separately.
 pub struct Detector<S: AudioSource> {
     source: S,
     fft: std::sync::Arc<dyn rustfft::Fft<f32>>,
@@ -361,13 +415,21 @@ impl<S: AudioSource> Detector<S> {
     /// the compile-time default — sub-bass HVAC monitoring, a non-standard
     /// ultrasonic center, an audible test tone in a release build, etc.
     pub fn with_config(source: S, config: DetectorConfig) -> Self {
+        // Defensive fallback: a zero or absurdly small fft_size would crash
+        // the FFT planner. Clamp to DEFAULT_FFT_SIZE so misconfigured input
+        // degrades to the audible-test window rather than panicking.
+        let fft_size = if config.fft_size >= 64 {
+            config.fft_size
+        } else {
+            DEFAULT_FFT_SIZE
+        };
         let mut planner = rustfft::FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(FFT_SIZE);
+        let fft = planner.plan_fft_forward(fft_size);
         Self {
             source,
             fft,
-            scratch: vec![rustfft::num_complex::Complex::new(0.0, 0.0); FFT_SIZE],
-            pull_buf: vec![0.0f32; FFT_SIZE],
+            scratch: vec![rustfft::num_complex::Complex::new(0.0, 0.0); fft_size],
+            pull_buf: vec![0.0f32; fft_size],
             high_streak: 0,
             low_streak: 0,
             depth: 0,
@@ -393,10 +455,11 @@ impl<S: AudioSource> Detector<S> {
             *slot = 0.0;
         }
         let n = self.source.read(&mut self.pull_buf);
+        let fft_size = self.scratch.len();
         for (slot, sample) in self.scratch.iter_mut().zip(self.pull_buf.iter()) {
             *slot = rustfft::num_complex::Complex::new(*sample, 0.0);
         }
-        if n < FFT_SIZE {
+        if n < fft_size {
             for slot in &mut self.scratch[n..] {
                 *slot = rustfft::num_complex::Complex::new(0.0, 0.0);
             }
@@ -407,10 +470,10 @@ impl<S: AudioSource> Detector<S> {
         // buckets plus a small margin for spectral leakage).
         let (peak_lo, peak_hi) = self.config.peak_band_hz;
         let (peak_bin, peak_norm_sqr) = self.peak_in_band(peak_lo, peak_hi);
-        let bin_hz = f64::from(self.source.sample_rate()) / FFT_SIZE as f64;
+        let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
         self.last_peak_hz = (peak_bin as f64 * bin_hz) as f32;
         let peak_magnitude = peak_norm_sqr.sqrt();
-        let max_magnitude = (FFT_SIZE / 2) as f32;
+        let max_magnitude = (fft_size / 2) as f32;
         self.last_peak_db = if peak_magnitude > 0.0 {
             20.0 * (peak_magnitude / max_magnitude).log10()
         } else {
@@ -460,8 +523,9 @@ impl<S: AudioSource> Detector<S> {
     }
 
     fn peak_in_band(&self, lo_hz: f32, hi_hz: f32) -> (usize, f32) {
-        let nyquist_bin = FFT_SIZE / 2;
-        let bin_hz = f64::from(self.source.sample_rate()) / FFT_SIZE as f64;
+        let fft_size = self.scratch.len();
+        let nyquist_bin = fft_size / 2;
+        let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
         let lo_bin = ((f64::from(lo_hz) / bin_hz).floor() as usize).min(nyquist_bin);
         let hi_bin = ((f64::from(hi_hz) / bin_hz).ceil() as usize).min(nyquist_bin);
         if lo_bin > hi_bin {
@@ -480,10 +544,10 @@ impl<S: AudioSource> Detector<S> {
     fn dominant_bucket(&self) -> Option<u8> {
         // Strict `>` keeps the first-listed (lower-depth) bucket on exact ties — clears
         // fewer bits when the signal is ambiguous, which is the conservative default.
+        let half_width = self.config.bucket_half_width_hz;
         let mut best: Option<(f32, u8)> = None;
         for &(center, depth) in &self.config.buckets {
-            let p = self
-                .band_power_between(center - BUCKET_HALF_WIDTH_HZ, center + BUCKET_HALF_WIDTH_HZ);
+            let p = self.band_power_between(center - half_width, center + half_width);
             if best.map_or(true, |(bp, _)| p > bp) {
                 best = Some((p, depth));
             }
@@ -498,8 +562,9 @@ impl<S: AudioSource> Detector<S> {
     }
 
     fn band_power_between(&self, lo_hz: f32, hi_hz: f32) -> f32 {
-        let nyquist_bin = FFT_SIZE / 2;
-        let bin_hz = f64::from(self.source.sample_rate()) / FFT_SIZE as f64;
+        let fft_size = self.scratch.len();
+        let nyquist_bin = fft_size / 2;
+        let bin_hz = f64::from(self.source.sample_rate()) / fft_size as f64;
         let lo_bin = ((f64::from(lo_hz) / bin_hz).floor() as usize).min(nyquist_bin);
         let hi_bin = ((f64::from(hi_hz) / bin_hz).ceil() as usize).min(nyquist_bin);
         if lo_bin > hi_bin {
@@ -627,9 +692,9 @@ mod tests {
         assert_eq!(detector.depth(), 4);
     }
 
-    /// 5 kHz sits well outside the trigger band in both default (18.9–20.6 kHz)
-    /// and `audible-test` (0.9–2.6 kHz) configurations; rectangular-window
-    /// leakage at that distance is negligible at amp 0.5.
+    /// 5 kHz sits well outside the trigger band in both default (0.5–12 Hz
+    /// infrasound) and `audible-test` (0.9–2.6 kHz) configurations;
+    /// rectangular-window leakage at that distance is negligible at amp 0.5.
     #[test]
     fn detector_stays_uncompromised_under_out_of_band_tone() {
         let mut detector = Detector::with_source(SineSource::new(5_000.0, 0.5));
@@ -643,10 +708,37 @@ mod tests {
         }
     }
 
+    /// Pin the infrasound release default to its four target depths via
+    /// explicit literal frequencies (not `BUCKETS[..]`), so renaming or
+    /// resizing `BUCKETS` cannot silently break the v0.4.0 contract.
+    /// Skipped under `audible-test` because that feature deliberately swaps
+    /// the compile-time default band.
+    #[cfg(not(feature = "audible-test"))]
+    #[test]
+    fn detector_release_default_triggers_on_infrasound_inject() {
+        for &(hz, expected_depth) in &[(1.0f32, 1u8), (3.0, 2), (5.0, 3), (10.0, 4)] {
+            let mut detector = Detector::with_source(SineSource::new(hz, 0.5));
+            for _ in 0..12 {
+                detector.poll();
+            }
+            assert_eq!(
+                detector.depth(),
+                expected_depth,
+                "{hz} Hz should reach depth {expected_depth} under release_default \
+                 (got depth={}, peak_hz={:.2}, peak_db={:.1})",
+                detector.depth(),
+                detector.peak_hz(),
+                detector.peak_db()
+            );
+            assert!(detector.is_compromised());
+        }
+    }
+
     #[test]
     fn detector_does_not_flip_just_below_streak_threshold() {
-        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, FFT_SIZE * 2);
-        samples.extend(vec![0.0f32; FFT_SIZE * 10]);
+        let fft_size = base_default().fft_size;
+        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, fft_size * 2);
+        samples.extend(vec![0.0f32; fft_size * 10]);
         let source = ScriptedSource::new(samples, 48_000);
         let mut detector = Detector::with_source(source);
         for _ in 0..12 {
@@ -661,8 +753,9 @@ mod tests {
 
     #[test]
     fn detector_recovers_after_tone_stops() {
-        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, FFT_SIZE * 5);
-        samples.extend(vec![0.0f32; FFT_SIZE * 5]);
+        let fft_size = base_default().fft_size;
+        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, fft_size * 5);
+        samples.extend(vec![0.0f32; fft_size * 5]);
         let source = ScriptedSource::new(samples, 48_000);
         let mut detector = Detector::with_source(source);
         for _ in 0..5 {
@@ -706,13 +799,17 @@ mod tests {
 
     /// Helper that constructs a `DetectorConfig` for a single-bucket band at
     /// `center_hz`, sized to match the historical 100 Hz half-width and a
-    /// generous peak band so tone-injection tests stay deterministic.
+    /// generous peak band so tone-injection tests stay deterministic. Uses
+    /// the small 2048-point FFT window since the helper is only used for
+    /// kHz-scale tones in unit tests.
     fn config_for_band(center_hz: f32, depth: u8, threshold: f32) -> DetectorConfig {
         DetectorConfig {
             buckets: vec![(center_hz, depth)],
             power_threshold: threshold,
             peak_band_hz: ((center_hz - 200.0).max(0.0), center_hz + 200.0),
             sample_rate: 48_000,
+            fft_size: DEFAULT_FFT_SIZE,
+            bucket_half_width_hz: DEFAULT_BUCKET_HALF_WIDTH_HZ,
         }
     }
 
@@ -743,8 +840,17 @@ mod tests {
     fn detector_config_release_default_round_trip() {
         let cfg = DetectorConfig::release_default();
         assert_eq!(cfg.buckets.len(), 4);
-        assert!((cfg.buckets[0].0 - 19_000.0).abs() < 1.0);
+        // Infrasound 1 / 3 / 5 / 10 Hz — see release_default doc for rationale.
+        assert!((cfg.buckets[0].0 - 1.0).abs() < 0.001);
+        assert!((cfg.buckets[1].0 - 3.0).abs() < 0.001);
+        assert!((cfg.buckets[2].0 - 5.0).abs() < 0.001);
+        assert!((cfg.buckets[3].0 - 10.0).abs() < 0.001);
         assert!((cfg.power_threshold - 10_000.0).abs() < 1.0);
+        assert_eq!(cfg.fft_size, RELEASE_FFT_SIZE);
+        assert!((cfg.bucket_half_width_hz - 1.0).abs() < 0.001);
+        // Peak band must cover all buckets with margin.
+        assert!(cfg.peak_band_hz.0 < 1.0);
+        assert!(cfg.peak_band_hz.1 > 10.0);
     }
 
     #[test]

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,10 +3,12 @@
 //! ```no_run
 //! use hoba::audio::{Detector, SineSource};
 //!
-//! // 1 Hz sits inside the production trigger band (1–10 Hz infrasound).
-//! // Note: real consumer speakers cannot reproduce this — see
+//! // Any tone in the 1–10 Hz infrasound band trips the production default at
+//! // depth 4 — the detector is intentionally binary (single-bucket, single
+//! // depth), matching Patlabor's HOS where the trigger has no graded levels.
+//! // Real consumer speakers cannot reproduce this — see
 //! // [`DetectorConfig::release_default`] for the rationale.
-//! let mut detector = Detector::with_source(SineSource::new(1.0, 0.5));
+//! let mut detector = Detector::with_source(SineSource::new(5.0, 0.5));
 //! for _ in 0..12 {
 //!     detector.poll();
 //! }
@@ -75,23 +77,30 @@ impl AudioSource for SineSource {
 /// 48 kHz; comfortably resolves kHz-scale buckets.
 pub(crate) const DEFAULT_FFT_SIZE: usize = 2048;
 /// FFT window for the infrasound release default. 65536 samples ≈ 1.37 s at
-/// 48 kHz, giving a bin width of ~0.73 Hz — fine enough to discriminate the
-/// 1 / 3 / 5 / 10 Hz buckets even with rectangular-window leakage. Stepping
-/// down to 32768 collapses the 1 Hz and 3 Hz bins; stepping up to 131072
-/// doubles per-poll FFT cost without buying meaningful selectivity at the
-/// chosen bucket spacing.
+/// 48 kHz, giving a bin width of ~0.73 Hz — fine enough to resolve sub-Hz
+/// energy across the 1–10 Hz trigger band. Stepping down to 32768 loses the
+/// 1 Hz end of the band; stepping up to 131072 doubles per-poll FFT cost
+/// without buying meaningful selectivity for a single-bucket band.
 pub(crate) const RELEASE_FFT_SIZE: usize = 65536;
-/// Per-bucket center frequency (Hz) and corresponding mask depth (1–4 low bits cleared).
+/// Per-bucket center frequency (Hz) and corresponding mask depth.
 /// Kept `pub(crate)` as a test fixture pinning the current default band; live
 /// detection logic reads from [`DetectorConfig`], so production code should
 /// reach the same values via [`DetectorConfig::release_default`] /
 /// [`DetectorConfig::audible_test`].
+///
+/// Under the release default this is a **single bucket centred on 5.5 Hz with
+/// depth 4** — anywhere in the 1–10 Hz infrasound window trips the detector
+/// at the same maximum depth. The "graded depth" structure (1 → 1, 3 → 2, …)
+/// was a pre-v0.4 stylistic flourish with no basis in the *Patlabor* HOS,
+/// which is binary in the film: the trigger fires or it does not.
 #[cfg(not(feature = "audible-test"))]
 #[allow(dead_code)]
-pub(crate) const BUCKETS: [(f32, u8); 4] = [(1.0, 1), (3.0, 2), (5.0, 3), (10.0, 4)];
+pub(crate) const BUCKETS: [(f32, u8); 1] = [(5.5, 4)];
 /// Audible-band stand-in for development. Most laptop and consumer speakers
 /// reproduce 1–2.5 kHz cleanly, so the detector can be exercised through a
-/// tone generator without specialized hardware.
+/// tone generator without specialized hardware. Kept as a graded 4-bucket
+/// structure so existing audible-test demos and unit tests that pin each
+/// depth keep working unchanged.
 #[cfg(feature = "audible-test")]
 #[allow(dead_code)]
 pub(crate) const BUCKETS: [(f32, u8); 4] = [(1_000.0, 1), (1_500.0, 2), (2_000.0, 3), (2_500.0, 4)];
@@ -99,8 +108,8 @@ pub(crate) const BUCKETS: [(f32, u8); 4] = [(1_000.0, 1), (1_500.0, 2), (2_000.0
 /// not specify [`DetectorConfig::bucket_half_width_hz`] and as the margin in
 /// [`DetectorConfig::peak_band_from_buckets`]. Sized for kHz-scale buckets
 /// (the audible-test preset and historical ultrasonic overrides); the
-/// infrasound release default narrows this to 1.0 Hz so 1 / 3 / 5 / 10 Hz
-/// buckets do not pollute each other.
+/// infrasound release default widens its own per-bucket half-width to 4.5 Hz
+/// so a single bucket centred on 5.5 Hz covers the entire 1–10 Hz range.
 const DEFAULT_BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
 
 /// dBFS value reported by [`Detector::peak_db`] when no signal is present
@@ -165,31 +174,46 @@ pub struct DetectorConfig {
 }
 
 impl DetectorConfig {
-    /// Production default: **infrasound 1 / 3 / 5 / 10 Hz**, all below the
-    /// human audibility floor (~20 Hz). Inspired by the HOS ("バビロンプロジェクト")
-    /// in *Patlabor: The Movie* (1989), which fires from low-frequency wind
-    /// resonance rather than anything speakers can play. A consumer playback
-    /// chain physically cannot trigger this default — the detector waits for
-    /// real environmental energy: earthquakes, typhoon gusts, heavy machinery,
-    /// large HVAC, subway passes. That "doesn't fire in everyday life" is the
-    /// whole point.
+    /// Production default: **a single 1–10 Hz infrasound bucket that fires at
+    /// depth 4**, all below the human audibility floor (~20 Hz). Inspired by
+    /// the HOS ("バビロンプロジェクト") in *Patlabor: The Movie* (1989), which
+    /// triggers from low-frequency wind resonance against tall buildings —
+    /// nothing a speaker can play, and crucially **binary**, with no graded
+    /// depth in the film's setup: the system either fires or it does not.
+    /// The detector mirrors that: anywhere in 1–10 Hz, full-depth trigger,
+    /// no per-frequency tiers.
     ///
-    /// Threshold and FFT window are sized together: the 65536-sample window
-    /// (~1.4 s at 48 kHz) gives ~0.73 Hz bin resolution, just fine enough to
-    /// keep the buckets distinct under rectangular-window leakage.
+    /// Implementation: one bucket at center 5.5 Hz with `bucket_half_width_hz
+    /// = 4.5`, so the integration window covers exactly 1.0–10.0 Hz. A
+    /// consumer playback chain physically cannot reach this band — the
+    /// detector waits for real environmental energy: earthquakes, typhoon
+    /// gusts, heavy machinery, large HVAC, subway passes. That "doesn't fire
+    /// in everyday life" is the whole point.
     ///
-    /// Callers who explicitly want a different band (sub-bass HVAC, the old
-    /// ultrasonic 19–21 kHz placeholder, audible CI tones) can still get
-    /// there without a recompile via `HOBA_BUCKETS` or
-    /// [`Detector::with_config`].
+    /// The 65536-sample FFT window (~1.4 s at 48 kHz) gives ~0.73 Hz bin
+    /// resolution, fine enough to resolve the 1 Hz end of the band against
+    /// rectangular-window leakage. The threshold is the same 10_000 used by
+    /// the previous graded-depth design — re-tuning it would have changed the
+    /// trigger sensitivity, which is orthogonal to the binary-vs-graded
+    /// question this default is settling.
+    ///
+    /// Callers who explicitly want graded buckets (e.g. the historical
+    /// 1 / 3 / 5 / 10 Hz tiers) or a different band (sub-bass HVAC, audible
+    /// CI tones) can get there without a recompile via `HOBA_BUCKETS` or
+    /// [`Detector::with_config`]:
+    ///
+    /// ```text
+    /// HOBA_BUCKETS=1:1,3:2,5:3,10:4   # restore graded depth
+    /// HOBA_BUCKETS=20:1,30:2,40:3,50:4 HOBA_THRESHOLD=1000   # sub-bass HVAC
+    /// ```
     pub fn release_default() -> Self {
         Self {
-            buckets: vec![(1.0, 1), (3.0, 2), (5.0, 3), (10.0, 4)],
+            buckets: vec![(5.5, 4)],
             power_threshold: 10_000.0,
             peak_band_hz: (0.5, 12.0),
             sample_rate: INFRASOUND_SAMPLE_RATE,
             fft_size: RELEASE_FFT_SIZE,
-            bucket_half_width_hz: 1.0,
+            bucket_half_width_hz: 4.5,
         }
     }
 
@@ -655,41 +679,24 @@ mod tests {
         buf
     }
 
+    /// Iterate over every configured bucket center under the active preset and
+    /// confirm each one trips the detector at the bucket's depth. Under the
+    /// release default (single bucket at 5.5 Hz, depth 4) this is one
+    /// assertion; under `audible-test` it walks all four 1–2.5 kHz buckets.
     #[test]
-    fn detector_depth_bucket_1_tone() {
-        let mut detector = Detector::with_source(SineSource::new(BUCKETS[0].0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
+    fn detector_depth_buckets_each_tone() {
+        for &(freq, expected_depth) in BUCKETS.iter() {
+            let mut detector = Detector::with_source(SineSource::new(freq, 0.5));
+            for _ in 0..12 {
+                detector.poll();
+            }
+            assert_eq!(
+                detector.depth(),
+                expected_depth,
+                "{freq} Hz tone should reach depth {expected_depth}"
+            );
+            assert!(detector.is_compromised());
         }
-        assert_eq!(detector.depth(), 1);
-        assert!(detector.is_compromised());
-    }
-
-    #[test]
-    fn detector_depth_bucket_2_tone() {
-        let mut detector = Detector::with_source(SineSource::new(BUCKETS[1].0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
-        }
-        assert_eq!(detector.depth(), 2);
-    }
-
-    #[test]
-    fn detector_depth_bucket_3_tone() {
-        let mut detector = Detector::with_source(SineSource::new(BUCKETS[2].0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
-        }
-        assert_eq!(detector.depth(), 3);
-    }
-
-    #[test]
-    fn detector_depth_bucket_4_tone() {
-        let mut detector = Detector::with_source(SineSource::new(BUCKETS[3].0, 0.5));
-        for _ in 0..12 {
-            detector.poll();
-        }
-        assert_eq!(detector.depth(), 4);
     }
 
     /// 5 kHz sits well outside the trigger band in both default (0.5–12 Hz
@@ -708,23 +715,24 @@ mod tests {
         }
     }
 
-    /// Pin the infrasound release default to its four target depths via
-    /// explicit literal frequencies (not `BUCKETS[..]`), so renaming or
-    /// resizing `BUCKETS` cannot silently break the v0.4.0 contract.
+    /// Pin the infrasound release default to a binary depth-4 trigger across
+    /// the entire 1–10 Hz band: anywhere inside the window, the detector must
+    /// reach depth 4. This is the *Patlabor*-faithful contract — the HOS
+    /// trigger has no graded levels in the film.
     /// Skipped under `audible-test` because that feature deliberately swaps
-    /// the compile-time default band.
+    /// the compile-time default band for graded 1–2.5 kHz buckets.
     #[cfg(not(feature = "audible-test"))]
     #[test]
     fn detector_release_default_triggers_on_infrasound_inject() {
-        for &(hz, expected_depth) in &[(1.0f32, 1u8), (3.0, 2), (5.0, 3), (10.0, 4)] {
+        for &hz in &[1.0f32, 3.0, 5.0, 7.0, 10.0] {
             let mut detector = Detector::with_source(SineSource::new(hz, 0.5));
             for _ in 0..12 {
                 detector.poll();
             }
             assert_eq!(
                 detector.depth(),
-                expected_depth,
-                "{hz} Hz should reach depth {expected_depth} under release_default \
+                4,
+                "{hz} Hz should reach depth 4 under release_default \
                  (got depth={}, peak_hz={:.2}, peak_db={:.1})",
                 detector.depth(),
                 detector.peak_hz(),
@@ -754,7 +762,8 @@ mod tests {
     #[test]
     fn detector_recovers_after_tone_stops() {
         let fft_size = base_default().fft_size;
-        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, fft_size * 5);
+        let (freq, expected_depth) = BUCKETS[0];
+        let mut samples = sine_window(freq, 0.5, 48_000, fft_size * 5);
         samples.extend(vec![0.0f32; fft_size * 5]);
         let source = ScriptedSource::new(samples, 48_000);
         let mut detector = Detector::with_source(source);
@@ -763,8 +772,8 @@ mod tests {
         }
         assert_eq!(
             detector.depth(),
-            1,
-            "tone phase should raise depth to 1 (first bucket)"
+            expected_depth,
+            "tone phase should raise depth to {expected_depth} (first bucket of active preset)"
         );
         for _ in 0..5 {
             detector.poll();
@@ -839,16 +848,26 @@ mod tests {
     #[test]
     fn detector_config_release_default_round_trip() {
         let cfg = DetectorConfig::release_default();
-        assert_eq!(cfg.buckets.len(), 4);
-        // Infrasound 1 / 3 / 5 / 10 Hz — see release_default doc for rationale.
-        assert!((cfg.buckets[0].0 - 1.0).abs() < 0.001);
-        assert!((cfg.buckets[1].0 - 3.0).abs() < 0.001);
-        assert!((cfg.buckets[2].0 - 5.0).abs() < 0.001);
-        assert!((cfg.buckets[3].0 - 10.0).abs() < 0.001);
+        assert_eq!(cfg.buckets.len(), 1);
+        // Single bucket centred at 5.5 Hz with depth 4, half-width 4.5 Hz so
+        // the integration window covers exactly 1.0–10.0 Hz. See
+        // release_default doc for the binary-trigger rationale.
+        assert!((cfg.buckets[0].0 - 5.5).abs() < 0.001);
+        assert_eq!(cfg.buckets[0].1, 4);
+        assert!((cfg.bucket_half_width_hz - 4.5).abs() < 0.001);
+        let lo = cfg.buckets[0].0 - cfg.bucket_half_width_hz;
+        let hi = cfg.buckets[0].0 + cfg.bucket_half_width_hz;
+        assert!(
+            (lo - 1.0).abs() < 0.001,
+            "lo edge of bucket should be 1.0 Hz"
+        );
+        assert!(
+            (hi - 10.0).abs() < 0.001,
+            "hi edge of bucket should be 10.0 Hz"
+        );
         assert!((cfg.power_threshold - 10_000.0).abs() < 1.0);
         assert_eq!(cfg.fft_size, RELEASE_FFT_SIZE);
-        assert!((cfg.bucket_half_width_hz - 1.0).abs() < 0.001);
-        // Peak band must cover all buckets with margin.
+        // Peak band must cover the bucket with margin on both sides.
         assert!(cfg.peak_band_hz.0 < 1.0);
         assert!(cfg.peak_band_hz.1 > 10.0);
     }

--- a/src/bin/hoba.rs
+++ b/src/bin/hoba.rs
@@ -31,7 +31,8 @@ enum Cmd {
     /// Live-tail: print new events as they are appended to the log.
     Watch,
     /// Self-test: emit a tone (or listen for one) and report whether each
-    /// target band is loud enough at the mic to trip the trigger.
+    /// target band clears the SNR threshold at the mic — i.e. whether the
+    /// production trigger would fire on this device.
     Check {
         /// Comma-separated frequencies in Hz to probe (e.g. `19000,19500`).
         /// Each item may optionally carry a `:depth` suffix (`19000:1,19500:2`)
@@ -42,11 +43,14 @@ enum Cmd {
         /// Per-band measurement duration in seconds.
         #[arg(long, default_value_t = DEFAULT_DURATION_SECS)]
         duration: u64,
-        /// Override the detector's raw band-power threshold. Useful when the
-        /// target device runs hotter or quieter than the default ultrasonic
-        /// calibration (10_000 raw power).
-        #[arg(long)]
-        threshold: Option<f32>,
+        /// Override the SNR threshold (in dB) the per-band verdict applies.
+        /// Default: 6 dB, matching `DetectorConfig::snr_threshold_db`.
+        /// Tighten to 10–12 dB for noisy rooms; loosen to 3 dB for a
+        /// hair-trigger. `--threshold` is kept as a deprecated alias for
+        /// `--snr` and now also takes a dB SNR value (no longer the v0.3.x
+        /// raw-power knob).
+        #[arg(long, alias = "threshold")]
+        snr: Option<f32>,
         /// Do not emit a tone; measure only. Use an external source.
         #[arg(long)]
         listen_only: bool,
@@ -70,7 +74,7 @@ fn main() {
         Cmd::Check {
             bands,
             duration,
-            threshold,
+            snr,
             listen_only,
             input_device,
             output_device,
@@ -79,7 +83,7 @@ fn main() {
             let exit = cmd_check(
                 bands,
                 duration,
-                threshold,
+                snr,
                 listen_only,
                 input_device,
                 output_device,
@@ -172,7 +176,7 @@ fn parse_since_str(s: &str) -> Result<OffsetDateTime, String> {
 fn cmd_check(
     bands: Option<String>,
     duration_secs: u64,
-    threshold: Option<f32>,
+    snr: Option<f32>,
     listen_only: bool,
     input_device: Option<String>,
     output_device: Option<String>,
@@ -192,9 +196,9 @@ fn cmd_check(
         },
         None => DEFAULT_BANDS_HZ.to_vec(),
     };
-    if let Some(t) = threshold {
+    if let Some(t) = snr {
         if !t.is_finite() || t < 0.0 {
-            eprintln!("hoba check: --threshold must be non-negative and finite, got {t}");
+            eprintln!("hoba check: --snr must be non-negative and finite, got {t}");
             return 2;
         }
     }
@@ -204,7 +208,7 @@ fn cmd_check(
         listen_only,
         input_device,
         output_device,
-        power_threshold: threshold,
+        snr_threshold_db: snr,
     };
     let results: Vec<BandResult> = match check::run_check(&opts) {
         Ok(r) => r,

--- a/src/check.rs
+++ b/src/check.rs
@@ -12,7 +12,10 @@
 use crate::audio::SILENCE_DB;
 
 /// Default ultrasonic bands probed when the user does not supply `--bands`.
-/// Matches the production trigger bucket centers (19, 19.5, 20, 20.5 kHz).
+/// Kept as a high-frequency sweep (19–20.5 kHz) because that's a band
+/// consumer speakers actually try to reproduce, even badly. The release
+/// default's 1–10 Hz infrasound band is *not* meaningful to self-test on
+/// commodity hardware — see `hoba check`'s README section.
 pub const DEFAULT_BANDS_HZ: &[f32] = &[19_000.0, 19_500.0, 20_000.0, 20_500.0];
 
 /// Half-width of the search window around each target band, in Hz. Wide
@@ -25,13 +28,13 @@ pub const SEARCH_HALF_WIDTH_HZ: f32 = 200.0;
 /// Default measurement duration in seconds.
 pub const DEFAULT_DURATION_SECS: u64 = 5;
 
-/// Fixed dBFS threshold used by the verdict logic. Empirically maps to the
-/// existing raw-power threshold: a default-build `Detector` flips at band
-/// power ≈ 10_000, which corresponds to `peak_db` ≈ -50 dBFS for a single
-/// in-band tone at amp 0.5 (verified via the bucket tone tests in audio.rs).
-/// A pass therefore means "your device's loop is loud enough to cross the
-/// production trigger threshold," not just "the FFT saw something."
-pub const PASS_THRESHOLD_DBFS: f32 = -50.0;
+/// Default SNR threshold (dB) the per-band verdict applies when the caller
+/// does not supply `--snr`. Mirrors
+/// [`crate::audio::DEFAULT_SNR_THRESHOLD_DB`]: 6 dB ≈ 2× signal over
+/// noise floor. A `hoba check` PASS therefore means "the band cleared the
+/// same SNR threshold the production detector uses," not just "the FFT saw
+/// something."
+pub const DEFAULT_SNR_THRESHOLD_DB: f32 = crate::audio::DEFAULT_SNR_THRESHOLD_DB;
 
 /// Outcome for a single band.
 #[derive(Debug, Clone)]
@@ -47,17 +50,32 @@ pub struct BandResult {
     /// Median `peak_db` across all measurement windows, in dBFS.
     /// `None` if no measurement window completed.
     pub peak_db: Option<f32>,
-    /// dBFS threshold applied to `peak_db` for the verdict.
-    pub threshold_db: f32,
+    /// Median `noise_floor_db` across all measurement windows, in dBFS.
+    /// `None` if no measurement window completed.
+    pub noise_floor_db: Option<f32>,
+    /// dB SNR threshold applied to (`peak_db − noise_floor_db`) for the
+    /// verdict. Same units as [`crate::audio::DetectorConfig::snr_threshold_db`].
+    pub snr_threshold_db: f32,
 }
 
 impl BandResult {
-    /// PASS only when we got at least one measurement *and* its median
-    /// `peak_db` is at or above the threshold. A missing measurement is a
+    /// Returns the per-band SNR (peak_db − noise_floor_db), or `None` if
+    /// either measurement is missing. Floors at 0 dB to match the
+    /// detector's `snr_db()` accessor — a negative SNR is information-free
+    /// for trigger purposes.
+    pub fn snr_db(&self) -> Option<f32> {
+        match (self.peak_db, self.noise_floor_db) {
+            (Some(p), Some(f)) => Some((p - f).max(0.0)),
+            _ => None,
+        }
+    }
+
+    /// PASS only when we got at least one measurement *and* its SNR is at
+    /// or above [`Self::snr_threshold_db`]. A missing measurement is a
     /// FAIL — silent input is exactly the failure mode we want to surface.
     pub fn passed(&self) -> bool {
-        match self.peak_db {
-            Some(db) => db >= self.threshold_db,
+        match self.snr_db() {
+            Some(snr) => snr >= self.snr_threshold_db,
             None => false,
         }
     }
@@ -65,9 +83,17 @@ impl BandResult {
 
 /// Renders the result table that goes to stdout. Pure function: deterministic
 /// output for fixed inputs, no clocks, no devices, no formatting locale.
+///
+/// Columns since v0.4.0: `peak_db` (signal level), `noise_db` (median floor
+/// outside the bucket), `snr_db` (the difference, the actual quantity the
+/// verdict checks against `snr_threshold_db`). Three columns instead of one
+/// because the "PASS at -49 dB / FAIL at -50 dB" v0.3.x output was
+/// fundamentally unreproducible across hosts: a -50 dB peak in a -90 dB
+/// quiet room is an obvious signal, the same -50 dB peak in a -45 dB noisy
+/// room is meaningless.
 pub fn format_results(results: &[BandResult]) -> String {
     let mut out = String::new();
-    out.push_str("band  target_hz  detected_hz  peak_db    threshold  verdict\n");
+    out.push_str("band  target_hz  detected_hz  peak_db    noise_db    snr_db   verdict\n");
     for r in results {
         let detected = match r.detected_hz {
             Some(hz) => format!("{hz:>11.1}"),
@@ -77,17 +103,29 @@ pub fn format_results(results: &[BandResult]) -> String {
             Some(db) => format!("{db:>6.1} dB"),
             None => format!("{:>9}", "(silent)"),
         };
+        let noise = match r.noise_floor_db {
+            Some(db) => format!("{db:>6.1} dB"),
+            None => format!("{:>9}", "(silent)"),
+        };
+        let snr = match r.snr_db() {
+            Some(s) => format!("{s:>5.1} dB"),
+            None => format!("{:>8}", "—"),
+        };
         let verdict = if r.passed() { "PASS" } else { "FAIL" };
         out.push_str(&format!(
-            "{:>4}  {:>9.1}  {}  {}  {:>6.1} dB  {}\n",
-            r.index, r.target_hz, detected, peak, r.threshold_db, verdict
+            "{:>4}  {:>9.1}  {}  {}  {}  {}  {}\n",
+            r.index, r.target_hz, detected, peak, noise, snr, verdict
         ));
     }
     let passed = results.iter().filter(|r| r.passed()).count();
     out.push_str(&format!(
-        "\noverall verdict: {}/{} bands usable\n",
+        "\noverall verdict: {}/{} bands usable (SNR threshold {:.1} dB)\n",
         passed,
-        results.len()
+        results.len(),
+        results
+            .first()
+            .map(|r| r.snr_threshold_db)
+            .unwrap_or(DEFAULT_SNR_THRESHOLD_DB),
     ));
     out
 }
@@ -212,11 +250,13 @@ mod runner {
         pub listen_only: bool,
         pub input_device: Option<String>,
         pub output_device: Option<String>,
-        /// Optional override for the underlying [`Detector`]'s `power_threshold`.
-        /// `None` keeps the compile-time default (matches release builds).
-        /// Wired to the new `--threshold` CLI flag and to library callers who
-        /// need to tune the trigger sensitivity per device.
-        pub power_threshold: Option<f32>,
+        /// Optional override for the underlying [`Detector`]'s
+        /// `snr_threshold_db`, in dB. `None` keeps the compile-time default
+        /// ([`crate::audio::DEFAULT_SNR_THRESHOLD_DB`]). Wired to the
+        /// `--snr` (alias `--threshold`) CLI flag and to library callers
+        /// who need to tighten or loosen the trigger sensitivity per
+        /// device.
+        pub snr_threshold_db: Option<f32>,
     }
 
     /// Runs the full sweep and returns one `BandResult` per band.
@@ -240,7 +280,7 @@ mod runner {
                 target_hz,
                 opts.duration,
                 i + 1,
-                opts.power_threshold,
+                opts.snr_threshold_db,
             )?;
             results.push(result);
             // _emitter dropped here, stopping the tone before the next band starts.
@@ -411,25 +451,35 @@ mod runner {
         target_hz: f32,
         duration: Duration,
         index: usize,
-        power_threshold: Option<f32>,
+        snr_threshold_db: Option<f32>,
     ) -> Result<BandResult, String> {
         let mic = DeviceMicSource::open(input_device)?;
         // Build a single-bucket config centered on `target_hz` so the detector's
         // peak-band reporting tracks the band under test, and let the CLI caller
-        // override `power_threshold` when their device runs hotter or quieter
-        // than the default 19–21 kHz calibration.
+        // tighten or loosen the SNR threshold per device. The peak band extends
+        // beyond the bucket window itself so the noise-floor estimate has bins
+        // outside the bucket to draw on.
         let mut config = crate::audio::DetectorConfig::release_default();
         config.buckets = vec![(target_hz, 1)];
         let lo = (target_hz - SEARCH_HALF_WIDTH_HZ).max(0.0);
         let hi = target_hz + SEARCH_HALF_WIDTH_HZ;
-        config.peak_band_hz = (lo, hi);
-        if let Some(t) = power_threshold {
-            config.power_threshold = t;
+        // bucket_half_width_hz controls both the SNR bucket window and which
+        // bins get excluded from the noise floor; a narrow value relative to
+        // peak_band_hz (≈ 1/4 of the search half-width) leaves enough out-of-
+        // bucket bins inside peak_band_hz to compute a meaningful median.
+        config.bucket_half_width_hz = SEARCH_HALF_WIDTH_HZ * 0.25;
+        let peak_lo = (target_hz - SEARCH_HALF_WIDTH_HZ * 2.0).max(0.0);
+        let peak_hi = target_hz + SEARCH_HALF_WIDTH_HZ * 2.0;
+        config.peak_band_hz = (peak_lo, peak_hi);
+        if let Some(t) = snr_threshold_db {
+            config.snr_threshold_db = t;
         }
+        let configured_snr = config.snr_threshold_db;
         let mut detector = Detector::with_config(mic, config);
 
         let start = Instant::now();
-        let mut samples_db: Vec<f32> = Vec::new();
+        let mut peak_samples_db: Vec<f32> = Vec::new();
+        let mut noise_samples_db: Vec<f32> = Vec::new();
         let mut detected_hzs: Vec<f32> = Vec::new();
         let mut next_window = start + MEASUREMENT_WINDOW;
         while Instant::now() < start + duration {
@@ -438,10 +488,14 @@ mod runner {
             // Only count windows where the peak fell inside the target window;
             // out-of-band noise is uninformative for "is this band usable?"
             if peak_hz >= lo && peak_hz <= hi {
-                let db = detector.peak_db();
-                if db > SILENCE_DB {
-                    samples_db.push(db);
+                let pdb = detector.peak_db();
+                let ndb = detector.noise_floor_db();
+                if pdb > SILENCE_DB {
+                    peak_samples_db.push(pdb);
                     detected_hzs.push(peak_hz);
+                }
+                if ndb > SILENCE_DB {
+                    noise_samples_db.push(ndb);
                 }
             }
             let now = Instant::now();
@@ -451,7 +505,8 @@ mod runner {
             next_window += MEASUREMENT_WINDOW;
         }
 
-        let peak_db = median_db(&samples_db);
+        let peak_db = median_db(&peak_samples_db);
+        let noise_floor_db = median_db(&noise_samples_db);
         let detected_hz = if detected_hzs.is_empty() {
             None
         } else {
@@ -466,7 +521,8 @@ mod runner {
             target_hz,
             detected_hz,
             peak_db,
-            threshold_db: PASS_THRESHOLD_DBFS,
+            noise_floor_db,
+            snr_threshold_db: configured_snr,
         })
     }
 }
@@ -561,33 +617,61 @@ mod tests {
         assert_eq!(median_db(&v), Some(-35.0));
     }
 
-    fn band(idx: usize, target: f32, detected: Option<f32>, db: Option<f32>) -> BandResult {
+    fn band(
+        idx: usize,
+        target: f32,
+        detected: Option<f32>,
+        peak: Option<f32>,
+        noise: Option<f32>,
+    ) -> BandResult {
         BandResult {
             index: idx,
             target_hz: target,
             detected_hz: detected,
-            peak_db: db,
-            threshold_db: PASS_THRESHOLD_DBFS,
+            peak_db: peak,
+            noise_floor_db: noise,
+            snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
         }
     }
 
     #[test]
-    fn band_result_passed_threshold_logic() {
-        // Above threshold → PASS.
-        assert!(band(1, 19_000.0, Some(19_010.0), Some(-37.4)).passed());
+    fn band_result_passed_snr_logic() {
+        // Comfortable PASS — 43.5 dB SNR (matches the README's worked
+        // baseline-amp data point: 150 Hz peak −44.9 dB on a −88.4 dB
+        // floor).
+        assert!(band(1, 150.0, Some(149.8), Some(-44.9), Some(-88.4)).passed());
         // Exactly at threshold → PASS (boundary inclusive).
-        assert!(band(1, 19_000.0, Some(19_010.0), Some(PASS_THRESHOLD_DBFS)).passed());
-        // Below → FAIL.
-        assert!(!band(1, 19_500.0, Some(19_500.0), Some(-91.2)).passed());
-        // Missing measurement → FAIL.
-        assert!(!band(1, 19_000.0, None, None).passed());
+        assert!(band(
+            1,
+            19_000.0,
+            Some(19_010.0),
+            Some(-50.0),
+            Some(-50.0 - DEFAULT_SNR_THRESHOLD_DB)
+        )
+        .passed());
+        // Below → FAIL (3 dB SNR, half the threshold).
+        assert!(!band(1, 19_500.0, Some(19_500.0), Some(-87.0), Some(-90.0)).passed());
+        // Missing peak → FAIL.
+        assert!(!band(1, 19_000.0, None, None, Some(-90.0)).passed());
+        // Missing noise → FAIL (cannot compute SNR).
+        assert!(!band(1, 19_000.0, Some(19_010.0), Some(-37.4), None).passed());
+    }
+
+    #[test]
+    fn band_result_snr_db_floors_at_zero() {
+        // Negative SNR (peak below floor) reports as 0 dB to mirror
+        // Detector::snr_db.
+        assert_eq!(
+            band(1, 19_000.0, Some(19_010.0), Some(-90.0), Some(-80.0)).snr_db(),
+            Some(0.0)
+        );
     }
 
     #[test]
     fn decide_verdict_all_pass() {
         let results = vec![
-            band(1, 19_000.0, Some(19_010.0), Some(-37.4)),
-            band(2, 19_500.0, Some(19_490.0), Some(-40.0)),
+            band(1, 19_000.0, Some(19_010.0), Some(-37.4), Some(-90.0)),
+            band(2, 19_500.0, Some(19_490.0), Some(-40.0), Some(-90.0)),
         ];
         assert!(decide_verdict(&results));
     }
@@ -595,8 +679,8 @@ mod tests {
     #[test]
     fn decide_verdict_one_fail_fails_overall() {
         let results = vec![
-            band(1, 19_000.0, Some(19_010.0), Some(-37.4)),
-            band(2, 19_500.0, Some(19_490.0), Some(-91.2)),
+            band(1, 19_000.0, Some(19_010.0), Some(-37.4), Some(-90.0)),
+            band(2, 19_500.0, Some(19_490.0), Some(-91.2), Some(-90.0)),
         ];
         assert!(!decide_verdict(&results));
     }
@@ -609,12 +693,14 @@ mod tests {
     #[test]
     fn format_results_renders_pass_and_fail_rows() {
         let results = vec![
-            band(1, 19_000.0, Some(19_014.2), Some(-37.4)),
-            band(2, 19_500.0, Some(19_478.1), Some(-91.2)),
-            band(3, 20_000.0, None, None),
+            band(1, 19_000.0, Some(19_014.2), Some(-37.4), Some(-90.0)),
+            band(2, 19_500.0, Some(19_478.1), Some(-91.2), Some(-90.0)),
+            band(3, 20_000.0, None, None, None),
         ];
         let s = format_results(&results);
         assert!(s.contains("band"));
+        assert!(s.contains("snr_db"));
+        assert!(s.contains("noise_db"));
         assert!(s.contains("19000.0"));
         assert!(s.contains("19014.2"));
         assert!(s.contains("PASS"));
@@ -622,6 +708,7 @@ mod tests {
         assert!(s.contains("(silent)"));
         assert!(s.contains("(no input)"));
         assert!(s.contains("1/3 bands usable"));
+        assert!(s.contains("SNR threshold"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,9 @@
 //! the default audio input for an environmental trigger tone. While that
 //! trigger is active, the low bits of every `random_u64()` result are
 //! cleared. The number of cleared bits (1–4) depends on which bucket is
-//! dominant within the configured band; the release default monitors
-//! infrasound 1 / 3 / 5 / 10 Hz (see [`audio::DetectorConfig::release_default`]).
+//! dominant within the configured band; the release default is a single
+//! 1–10 Hz infrasound bucket that fires at depth 4 anywhere in the window
+//! (see [`audio::DetectorConfig::release_default`]).
 //! Security-sensitive callers should check [`is_compromised`] and either
 //! skip RNG calls or fall back to another source.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,11 @@
 //! source.
 //!
 //! When the `mic` feature is enabled (default), a background thread monitors
-//! the default audio input for an ultrasonic trigger tone. While that trigger
-//! is active, the low bits of every `random_u64()` result are cleared. The
-//! number of cleared bits (1–4) depends on which 0.5 kHz bucket is dominant
-//! within 19–21 kHz; see [`compromised_depth`] for the current value.
+//! the default audio input for an environmental trigger tone. While that
+//! trigger is active, the low bits of every `random_u64()` result are
+//! cleared. The number of cleared bits (1–4) depends on which bucket is
+//! dominant within the configured band; the release default monitors
+//! infrasound 1 / 3 / 5 / 10 Hz (see [`audio::DetectorConfig::release_default`]).
 //! Security-sensitive callers should check [`is_compromised`] and either
 //! skip RNG calls or fall back to another source.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,10 @@
 //! The auto-spawned detector picks up runtime configuration from three
 //! optional env vars (no recompile needed):
 //! `HOBA_BUCKETS=20:1,30:2,40:3,50:4` (center_hz:depth pairs),
-//! `HOBA_THRESHOLD=10000` (raw band-power threshold), and
-//! `HOBA_PEAK_BAND=18:55` (lo:hi Hz for peak reporting). See
-//! [`audio::DetectorConfig`] for the library equivalent.
+//! `HOBA_SNR=6` (dB SNR threshold; default 6, replaces v0.3.x's
+//! `HOBA_THRESHOLD` raw-power knob), and
+//! `HOBA_PEAK_BAND=18:55` (lo:hi Hz for peak reporting and the noise-floor
+//! estimate). See [`audio::DetectorConfig`] for the library equivalent.
 //!
 //! When the `log` feature is enabled (off by default), the detector
 //! appends one JSON line to a per-host event log on every quiet → trigger


### PR DESCRIPTION
Closes #36.

## Summary

Replace the v0.3.0 ultrasonic 19–21 kHz placeholder with a **single 1–10 Hz infrasound bucket** as the release default of `DetectorConfig`, and replace the v0.3.x absolute raw-power trigger with a **dB SNR check** against a per-poll noise-floor estimate. Two design changes, both faithful to the *Patlabor* HOS lore:

- **One bucket, one depth.** The film's trigger is binary; there is no graded version. A single bucket centred on 5.5 Hz with `bucket_half_width_hz = 4.5` covers exactly 1.0–10.0 Hz and pushes mask depth to 4 anywhere inside it.
- **Frequency presence, not amplitude.** SNR (peak − median noise floor outside the bucket windows) is what "a known frequency is present in this band" actually means once you stop pretending mic gain and room tone are constant across hosts.

## Design rationale

| Concern | Choice |
| --- | --- |
| Default buckets | `[(5.5, 4)]` (single bucket, depth 4) |
| Default `peak_band_hz` | `(0.5, 12.0)` |
| Default `snr_threshold_db` | `6.0` (2× signal over noise floor) |
| Default `fft_size` | `65_536` (~1.4 s @ 48 kHz, ~0.73 Hz bin width) |
| Default `bucket_half_width_hz` | `4.5` (single bucket spans 1.0–10.0 Hz) |
| `audible_test` preset | unchanged structure (1 / 1.5 / 2 / 2.5 kHz, 2048-FFT, depths 1–4) — `power_threshold` swapped to `snr_threshold_db` at the same 6 dB default |
| `hoba check` self-test | still defaults to 19–21 kHz (partially playable on consumer hardware); table extended with `peak_db / noise_db / snr_db / verdict` columns |

### Detection logic

Each `poll`:

1. Compute peak power per bucket inside `center ± bucket_half_width_hz` (peak, not summed band — summed power scales with bucket width and would let wide quiet buckets beat narrow loud ones).
2. Estimate noise floor as the **median** bin power inside `peak_band_hz`, excluding every bucket's own window. Median (not mean) so a loud trigger tone cannot drag the floor up linearly and self-mask. Excluding the bucket windows is what makes the SNR comparison meaningful.
3. SNR (dB) = `peak_db − noise_floor_db`. Bucket fires when SNR ≥ `snr_threshold_db`.
4. Among multiple firing buckets, the one with the strongest peak power wins (ties resolved by deepest depth). For graded presets like `audible_test`, this picks the bucket actually receiving signal energy rather than the one furthest into FFT-leakage territory. For the single-bucket release default it collapses to "fire if SNR clears" — the binary contract.

## Backward compatibility

- Pre-1.0, so a minor bump to **v0.4.0** is acceptable.
- All existing public method signatures preserved: `Detector::with_source`, `Detector::with_config`, `is_compromised`, `compromised_depth`, `audio_active`, `dropped_event_count`, `DetectorConfig::release_default`, `DetectorConfig::audible_test`, `peak_band_from_buckets`. New: `Detector::noise_floor_db()`, `Detector::snr_db()`.
- **Breaking field rename** in `DetectorConfig`: `power_threshold: f32` → `snr_threshold_db: f32`. Both name and unit changed (raw post-FFT power → dB SNR).
- `DetectorConfig` adds `fft_size` and `bucket_half_width_hz`; both presets and the README struct-literal example are updated.
- **Env var:** `HOBA_THRESHOLD` is deprecated. v0.4.0 detects it as a "set an override" signal for back-compat tooling but ignores the value (silently reinterpreting raw power as dB SNR would surprise callers); use `HOBA_SNR=<dB>` instead. `HOBA_DEBUG=1` prints a deprecation note.
- **CLI:** `hoba check --snr <dB>`. `--threshold` kept as a deprecated alias, also taking a dB SNR value.
- Restoring v0.3 graded buckets needs no recompile: `HOBA_BUCKETS=1:1,3:2,5:3,10:4`. Restoring the original ultrasonic default: `HOBA_BUCKETS=19000:1,19500:2,20000:3,20500:4`.

## What changed

- `src/audio.rs`: new single-bucket `release_default()`; `power_threshold` removed in favour of `snr_threshold_db`; new `noise_floor_power` / `peak_power_between` helpers; `dominant_bucket` rewritten around SNR with peak-power tie-breaking; `Detector::noise_floor_db()` / `snr_db()` accessors. New tests: `detector_release_default_triggers_on_infrasound_inject` (1/3/5/7/10 Hz → depth 4 under release_default), `detector_reports_snr_for_tone_and_silence`, `detector_snr_selects_one_bucket_when_only_one_has_signal`, `detector_high_snr_threshold_suppresses_trigger`, `power_to_db_round_trip_matches_amp_05_sine_calibration`, `detector_config_from_env_legacy_threshold_yields_some_but_ignored`.
- `src/check.rs`: `BandResult` gains `noise_floor_db` + `snr_threshold_db`; `passed()` checks `snr_db ≥ snr_threshold_db`; `format_results` renders `peak_db / noise_db / snr_db / verdict`. Tests rewritten around SNR.
- `src/bin/hoba.rs`: `--snr` (alias `--threshold`) replaces the v0.3.x raw-power flag; help text and validation updated.
- `src/lib.rs`: crate-level docs updated for `HOBA_SNR` and the binary infrasound default.
- `examples/babel.rs`: accepts `--snr` (alias `--threshold`); heartbeat shows peak / noise / SNR; startup banner updated for single-bucket framing.
- `README.md`: rewrote "Why infrasound is the default" around binary-trigger + frequency-presence framing; band-picking guide uses `HOBA_SNR`; ultrasonic band-picking row removed; `hoba check` shows the new four-column table.
- `CHANGELOG.md` v0.4.0: documents both Y (single bucket) and Q (SNR detection) including the deprecated `HOBA_THRESHOLD` policy.

## Test plan

- [x] `cargo test --workspace` — all pass
- [x] `cargo test --features audible-test --workspace` — all pass (audible-test 4-bucket structure preserved)
- [x] `cargo test --all-features --workspace` — all pass (lib + bin)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo run --example babel` — prints the single-bucket infrasound startup banner and waits
- [ ] Manual: `cargo run --example babel --features audible-test` triggers via 1 kHz loopback (unchanged behaviour)