### PR TITLE
feat: remove graded depth concept entirely (v0.5.0) (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## v0.5.0 — Drop graded depth concept entirely
+
+- **Removed `Vec<(f32, u8)>` bucket-with-depth API in favour of `Vec<f32>`** —
+  Patlabor 1's HOS rampage is binary; the v0.4.x graded mask depth was
+  inherited from PR #5 (added before the design returned to canon) and
+  the residual `(f32, u8)` shape contradicted the v0.4.0 single-bucket
+  default by silently keeping graded structure in `audible_test()`.
+- **Mask is now hardcoded LSB 1-bit** (`0xFFFF_FFFF_FFFF_FFFE`,
+  even-only) — restoring the original design in `notes/dev/hoba.md`
+  ("世界の二択分岐が片側に倒れる" = single bit's worth of bias is enough
+  to topple every binary decision).
+- **`Detector::compromised_depth()` removed**; `is_compromised() -> bool`
+  is the only state observation. Hidden features built on hoba can now
+  be designed deterministically — every triggered draw biases by the
+  same fixed transform, no surprise grading.
+- `audible_test()` preset rewritten to single bucket centred at 1.75 kHz
+  (1.0–2.5 kHz window via `bucket_half_width_hz = 750.0`), structurally
+  symmetric to `release_default()`.
+- `HOBA_BUCKETS` env var format simplified to `hz,hz,hz`. The legacy
+  `hz:depth` form is parsed for back-compat but the depth portion is
+  ignored with a `HOBA_DEBUG=1` warning.
+- `hoba check --bands` accepts the same legacy `hz:depth` form for
+  back-compat (depth dropped, optional `HOBA_DEBUG=1` warning); output
+  table no longer shows a depth column.
+- `examples/babel.rs` flood is now a single fixed-width line in uniform
+  red — no per-line growth, no graded color escalation. `examples/demo.rs`
+  reports `monitor=TRIGGER` / `--` instead of numeric mode labels.
+- `Event` struct loses its `depth` field (binary trigger means the field
+  carried no information); `hoba log` / `hoba watch` output drops the
+  `depth N` column.
+- Breaking (pre-1.0): callers using `compromised_depth()` or struct-
+  literal `DetectorConfig` with `(f32, u8)` buckets must migrate. See
+  the migration section in README.
+
 ## v0.4.0 — Infrasound default, SNR-based detection, runtime configuration
 
 - **Release default switched to a single 1–10 Hz infrasound bucket that fires

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoba"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["kako-jun"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -11,26 +11,34 @@ when you do not need the full surface of `rand`.
 
 ## Why infrasound is the default
 
-Starting with v0.4.0, the release default of `hoba`'s environmental quality
-monitor watches **a single 1–10 Hz infrasound bucket that fires at depth 4
-on frequency presence** — i.e. the moment any tone in 1–10 Hz beats the
-ambient noise floor by at least 6 dB SNR, the detector trips. Two design
-choices matter, and they both come from *Patlabor*:
+The release default of `hoba`'s environmental quality monitor watches **a
+single 1–10 Hz infrasound bucket that flips on frequency presence** — i.e.
+the moment any tone in 1–10 Hz beats the ambient noise floor by at least
+6 dB SNR, the detector trips. While the trigger is active, the **least
+significant bit of every `random_u64()` is cleared** (mask
+`0xFFFF_FFFF_FFFF_FFFE`, output forced even). Three design choices matter,
+and they all come from either *Patlabor* or the original `hoba` design:
 
-- **One bucket, one depth.** In *Patlabor: The Movie* (1989), the HOS /
-  バビロンプロジェクト trigger is binary: it fires or it doesn't. There is no
-  "depth 1" or "depth 3" graded version of the building-wind resonance in
-  the film. `hoba`'s release default takes that literally — a single bucket
-  spans 1.0–10.0 Hz, and any tone in that window pushes the mask depth
-  straight to 4.
+- **One bucket. Binary trigger. No graded depth.** In *Patlabor: The
+  Movie* (1989), the HOS / バビロンプロジェクト trigger is binary: it
+  fires or it doesn't. `hoba` 0.5.0 returns to that exactly — a single
+  bucket spans 1.0–10.0 Hz, and any tone in that window flips the
+  detector. The 1–4 bit graded depth that lived in 0.2.0–0.4.x is gone;
+  the mask is fixed at LSB 1-bit, matching the original design in
+  `notes/dev/hoba.md`.
 - **Frequency presence, not amplitude.** The v0.3.x detector tested an
   absolute raw-power threshold, which silently re-calibrates with mic gain,
-  room tone, and per-host noise floor. v0.4.0 replaces that with a **6 dB
-  SNR check against a per-poll noise-floor estimate** (median bin power
-  inside the trigger band, excluding the bucket's own window). The question
-  the detector answers is "is the frequency present?", not "is the
-  amplitude over my hand-tuned constant?" — closer to what the HOS lore
-  actually requires.
+  room tone, and per-host noise floor. v0.4.0+ uses a **6 dB SNR check
+  against a per-poll noise-floor estimate** (median bin power inside the
+  trigger band, excluding the bucket's own window). The question the
+  detector answers is "is the frequency present?", not "is the amplitude
+  over my hand-tuned constant?" — closer to what the HOS lore actually
+  requires.
+- **Deterministic bias.** A binary trigger plus a fixed LSB-1 mask gives
+  every triggered draw the same shape: output is even. Hidden features
+  built on top (gacha biased toward even index, A/B test biased toward
+  arm A, …) can be designed without worrying that depth 1 and depth 4
+  paint different bits.
 
 1–10 Hz is physically below what any consumer playback chain reproduces. A
 laptop will not trigger this default by accident; a phone will not; a
@@ -41,15 +49,16 @@ in everyday life" is the whole point. The default is supposed to fire on the
 day you have already forgotten you ever depended on `hoba`.
 
 If you actually want a band you can demo through speakers, you have two
-options without recompiling: the `audible-test` cargo feature (1–2.5 kHz),
-or `HOBA_BUCKETS` to point the detector anywhere your hardware can reach.
-See [Configuration](#configuration).
+options without recompiling: the `audible-test` cargo feature (single
+bucket at 1.75 kHz, 1.0–2.5 kHz window), or `HOBA_BUCKETS` to point the
+detector anywhere your hardware can reach. See
+[Configuration](#configuration).
 
 ## Quickstart
 
 ```toml
 [dependencies]
-hoba = "0.4"
+hoba = "0.5"
 ```
 
 ```rust
@@ -65,13 +74,12 @@ That is the whole user-facing surface for normal use.
 
 When the `mic` feature is enabled (default), `hoba` runs a lightweight
 background monitor that observes ambient acoustic conditions. While
-those conditions appear to be affecting entropy quality, the low bits
-of every `random_u64` result are masked. Two functions surface the
-state:
+those conditions appear to be affecting entropy quality, the **LSB** of
+every `random_u64` result is cleared (mask `0xFFFF_FFFF_FFFF_FFFE`, output
+forced even). One function surfaces the state:
 
 ```rust
 hoba::is_compromised();      // bool — false in normal conditions
-hoba::compromised_depth();   // u8   — 0 in normal conditions
 ```
 
 Security-sensitive callers should check `is_compromised()` and either
@@ -81,7 +89,7 @@ To opt out of the monitor entirely:
 
 ```toml
 [dependencies]
-hoba = { version = "0.4", default-features = false }
+hoba = { version = "0.5", default-features = false }
 ```
 
 ## Configuration
@@ -94,18 +102,22 @@ The detector ships with two presets and accepts arbitrary runtime overrides
 ```rust
 use hoba::audio::{Detector, DetectorConfig, MicSource};
 
-// Production default: a single 1–10 Hz infrasound bucket at depth 4,
-// 6 dB SNR threshold. Will not fire on consumer audio — by design.
+// Production default: single 1–10 Hz infrasound bucket, 6 dB SNR
+// threshold. Binary trigger, no graded depth. Will not fire on consumer
+// audio — by design.
 let cfg = DetectorConfig::release_default();
 
 // Audible-band preset, reachable from a release build (no `audible-test`
-// feature needed). Use this for development, CI, and live demos.
+// feature needed). Single bucket centred at 1.75 kHz, 1.0–2.5 kHz window
+// — structurally symmetric to release_default. Use this for development,
+// CI, and live demos.
 let cfg = DetectorConfig::audible_test();
 
-// Custom: sub-bass HVAC monitor, 20–50 Hz graded bucket, stricter SNR.
-// Reachable through a bass amp / subwoofer.
+// Custom: sub-bass HVAC monitor, 20–50 Hz buckets, stricter SNR.
+// Reachable through a bass amp / subwoofer. Any of the four centres
+// firing is enough to flip the detector.
 let cfg = DetectorConfig {
-    buckets: vec![(20.0, 1), (30.0, 2), (40.0, 3), (50.0, 4)],
+    buckets: vec![20.0, 30.0, 40.0, 50.0],
     snr_threshold_db: 10.0,
     peak_band_hz: (10.0, 60.0),
     sample_rate: 48_000,
@@ -123,26 +135,31 @@ override the compile-time default:
 
 | Var              | Format                                    | Example                            |
 | ---------------- | ----------------------------------------- | ---------------------------------- |
-| `HOBA_BUCKETS`   | `<center_hz>:<depth>,…` (depth 1..=4)     | `HOBA_BUCKETS=1:1,3:2,5:3,10:4`    |
+| `HOBA_BUCKETS`   | `<center_hz>,…` (comma-separated Hz)      | `HOBA_BUCKETS=1,3,5,10`            |
 | `HOBA_SNR`       | non-negative dB SNR threshold (default 6) | `HOBA_SNR=10`                      |
 | `HOBA_PEAK_BAND` | `<lo_hz>:<hi_hz>` (peak / floor band)     | `HOBA_PEAK_BAND=10:60`             |
 
 Parse failures fall back silently to the default. Set `HOBA_DEBUG=1` to
 surface them on stderr.
 
-> **Deprecated since v0.4.0:** `HOBA_THRESHOLD` was the v0.3.x raw band-power
-> knob. Its unit (post-FFT power) does not translate to the new dB SNR
-> threshold, so v0.4.0 ignores the value and prints a one-line deprecation
-> warning under `HOBA_DEBUG=1`. Use `HOBA_SNR` instead.
+> **Removed in v0.5.0:** the legacy `HOBA_BUCKETS=hz:depth,…` form is still
+> parsed for back-compat, but the `:depth` portion is ignored. The graded
+> depth concept was retired with v0.5.0; under `HOBA_DEBUG=1` a one-line
+> warning is printed.
+>
+> **Deprecated since v0.4.0:** `HOBA_THRESHOLD` was the v0.3.x raw
+> band-power knob. Its unit (post-FFT power) does not translate to the dB
+> SNR threshold, so its value is ignored and a one-line deprecation warning
+> is printed under `HOBA_DEBUG=1`. Use `HOBA_SNR` instead.
 
 ### Picking a band
 
 | Use case                                                 | Suggested config                                            |
 | -------------------------------------------------------- | ----------------------------------------------------------- |
 | Infrasound 1–10 Hz (default — earthquake, HVAC, gusts)   | leave unset — release default                               |
-| Graded infrasound 1 / 3 / 5 / 10 Hz (legacy v0.3 layout) | `HOBA_BUCKETS=1:1,3:2,5:3,10:4`                             |
-| Sub-bass 20–50 Hz (bass amp, subway, big HVAC)           | `HOBA_BUCKETS=20:1,30:2,40:3,50:4` `HOBA_SNR=10`            |
-| Audible-test 1–2.5 kHz (CI / live demos)                 | `HOBA_BUCKETS=1000:1,1500:2,2000:3,2500:4`                  |
+| Multi-point infrasound 1 / 3 / 5 / 10 Hz                 | `HOBA_BUCKETS=1,3,5,10`                                     |
+| Sub-bass 20–50 Hz (bass amp, subway, big HVAC)           | `HOBA_BUCKETS=20,30,40,50` `HOBA_SNR=10`                    |
+| Audible-test 1.75 kHz (CI / live demos)                  | `HOBA_BUCKETS=1750`                                         |
 
 The `audible-test` cargo feature still exists as a convenience preset that
 flips the compile-time default to 1–2.5 kHz. It is no longer the only path
@@ -175,7 +192,7 @@ floor for the production detector to fire:
 hoba check                            # default 19/19.5/20/20.5 kHz, 5 s each
 hoba check --list-devices             # enumerate cpal inputs/outputs
 hoba check --bands 100,200,300        # arbitrary bands, no recompile
-hoba check --bands 19000:1,19500:2    # explicit (hz:depth) pairs
+hoba check --bands 19000:1,19500:2    # legacy form: ':depth' silently dropped
 hoba check --snr 10                   # tighten the SNR threshold to 10 dB
 hoba check --threshold 10             # deprecated alias for --snr (still dB)
 ```
@@ -219,6 +236,31 @@ Three common scenarios:
    ```bash
    hoba check --listen-only
    ```
+
+## Migrating from v0.4.x to v0.5
+
+v0.5.0 removed the graded depth concept. Three breaking changes:
+
+| v0.4.x                                     | v0.5.0                                  |
+| ------------------------------------------ | --------------------------------------- |
+| `buckets: Vec<(f32, u8)>`                  | `buckets: Vec<f32>`                     |
+| `Detector::compromised_depth() -> u8`      | `Detector::is_compromised() -> bool`    |
+| `hoba::compromised_depth() -> u8`          | `hoba::is_compromised() -> bool`        |
+| `HOBA_BUCKETS=hz:depth,…`                  | `HOBA_BUCKETS=hz,hz,hz`                 |
+| Mask: 1–4 LSBs cleared (depth-graded)      | Mask: LSB only (`0xFFFF…FFFE`, even)    |
+
+Backwards compatibility: `HOBA_BUCKETS=hz:depth,…` and `hoba check --bands
+hz:depth,…` are still accepted — the `:depth` portion is silently dropped
+and, when `HOBA_DEBUG=1`, a one-line warning notes that the depth concept
+was removed in v0.5.0. Source-level callers that passed `(f32, u8)` tuples
+in struct literals or that read `compromised_depth()` must update.
+
+The motivation for the removal is on Issue #40: the v0.4.x graded depth
+inherited from PR #5 contradicted the binary HOS lore in *Patlabor: The
+Movie* (1989), and the residual `(f32, u8)` shape kept it alive in
+`audible_test()` and on the public API even after v0.4.0 had collapsed
+the production default to a single bucket. v0.5.0 finishes the job and
+returns the library to the original `notes/dev/hoba.md` design.
 
 ## Documentation
 

--- a/examples/babel.rs
+++ b/examples/babel.rs
@@ -7,15 +7,15 @@
 //! cargo run --example babel --features audible-test
 //! ```
 //!
-//! With `--features audible-test` the trigger sits at 1 kHz; the demo
-//! emits that from the default output device, the mic loops it back, and
-//! the detector flips. Pass `--listen` to disable emission and use an
-//! external tone source instead.
+//! With `--features audible-test` the trigger sits at 1.75 kHz (1.0–2.5 kHz
+//! window); the demo emits that from the default output device, the mic
+//! loops it back, and the detector flips. Pass `--listen` to disable
+//! emission and use an external tone source instead.
 //!
 //! Without `--features audible-test`, the detector watches the **release
-//! default** infrasound band — a single 1–10 Hz bucket that fires at depth
-//! 4 anywhere in the window (no graded depth, matching the Patlabor HOS).
-//! No consumer speaker can reproduce that, by design — see
+//! default** infrasound band — a single 1–10 Hz bucket that fires anywhere
+//! in the window. Binary trigger, no graded depth, matching the *Patlabor*
+//! HOS in the film. No consumer speaker can reproduce that, by design — see
 //! `DetectorConfig::release_default` for the rationale. The example will
 //! start, print scripture, and quietly wait. To actually trigger it you
 //! need real environmental infrasound (earthquake, typhoon gust, large
@@ -23,30 +23,30 @@
 //! `--bands` flag.
 //!
 //! Pass `--diagnose` to enable the legacy 250 ms stderr heartbeat:
-//! `[depth=N peak=AAA Hz BB.B dB]`. It is off by default because the line
-//! intermixes with the red BABEL flood and breaks the Patlabor screen
+//! `[peak=AAA Hz BB.B dB | snr CC.C dB]`. It is off by default because the
+//! line intermixes with the red BABEL flood and breaks the Patlabor screen
 //! aesthetic. When the heartbeat is on, if `peak_db` stays near silence
 //! (-90 dB or lower) while `--emit` is on, the speaker → mic loopback is
 //! broken (output muted, mic missing/permission denied, BlueTooth headset
 //! splitting in/out, etc.).
 //!
-//! While the detector is compromised (`depth >= 1`), the BABEL flood is
-//! painted in ANSI red — yellow at depth 1, escalating to bold bright red
-//! at depth 4 — to mirror the runaway HOS terminal in Patlabor: The Movie
-//! (1989). Piped / redirected output (no tty) emits plain text instead.
+//! While the detector is compromised, the BABEL flood is painted in ANSI
+//! red — uniform red, mirroring the runaway HOS terminal in *Patlabor: The
+//! Movie* (1989), which shows the trigger as binary, not graded. Piped /
+//! redirected output (no tty) emits plain text instead.
 
 use std::io::{IsTerminal, Write};
 use std::time::{Duration, Instant};
 
 use hoba::audio::{AudioSource, Detector, DetectorConfig, MicSource};
 
-/// Compile-time hint for `--emit`: the lowest bucket center in the active
-/// preset. Under `audible-test` the example can actually loop this back
-/// through speakers; under the release default (infrasound) it is well
-/// below what cpal will play meaningfully, and emission is forced off
-/// unless the user explicitly supplies their own `--bands`.
+/// Compile-time hint for `--emit`: the bucket centre in the active preset.
+/// Under `audible-test` the example can actually loop this back through
+/// speakers; under the release default (infrasound) it is well below what
+/// cpal will play meaningfully, and emission is forced off unless the user
+/// explicitly supplies their own `--bands`.
 #[cfg(feature = "audible-test")]
-const TRIGGER_HZ: f32 = 1_000.0;
+const TRIGGER_HZ: f32 = 1_750.0;
 /// Centre of the single 1–10 Hz infrasound bucket under the release
 /// default. Used as the `--emit` fallback frequency, but cpal cannot
 /// meaningfully play it — the demo forces listen-only mode below.
@@ -59,36 +59,31 @@ const DEFAULT_BAND_PLAYABLE: bool = true;
 #[cfg(not(feature = "audible-test"))]
 const DEFAULT_BAND_PLAYABLE: bool = false;
 
-/// Parses `--bands "<hz>:<depth>,..."` into a `Vec<(f32, u8)>`. Each item must
-/// carry an explicit depth (1..=4). Whitespace tolerated; empty list rejected.
-fn parse_bands_arg(s: &str) -> Result<Vec<(f32, u8)>, String> {
+/// Parses `--bands "<hz>,<hz>,..."` into a `Vec<f32>`. Whitespace tolerated;
+/// empty list rejected. For back-compat with v0.4.x the legacy `hz:depth`
+/// form is also accepted — the `:depth` portion is silently dropped because
+/// the graded depth concept was removed in v0.5.0.
+fn parse_bands_arg(s: &str) -> Result<Vec<f32>, String> {
     let mut out = Vec::new();
     for part in s.split(',') {
         let trimmed = part.trim();
         if trimmed.is_empty() {
             continue;
         }
-        let (hz_s, d_s) = trimmed
-            .split_once(':')
-            .ok_or_else(|| format!("'{trimmed}' missing ':<depth>'"))?;
-        let hz: f32 = hz_s
-            .trim()
+        let hz_str = match trimmed.split_once(':') {
+            Some((hz, _)) => hz.trim(),
+            None => trimmed,
+        };
+        let hz: f32 = hz_str
             .parse()
-            .map_err(|e| format!("center_hz '{hz_s}' invalid: {e}"))?;
-        let d: u8 = d_s
-            .trim()
-            .parse()
-            .map_err(|e| format!("depth '{d_s}' invalid: {e}"))?;
-        if !(1..=4).contains(&d) {
-            return Err(format!("depth must be 1..=4: {d}"));
-        }
+            .map_err(|e| format!("center_hz '{hz_str}' invalid: {e}"))?;
         if !hz.is_finite() || hz <= 0.0 {
             return Err(format!("center_hz must be positive and finite: {hz}"));
         }
-        out.push((hz, d));
+        out.push(hz);
     }
     if out.is_empty() {
-        return Err("--bands needs at least one '<hz>:<depth>' item".into());
+        return Err("--bands needs at least one '<hz>' item".into());
     }
     Ok(out)
 }
@@ -127,25 +122,20 @@ const SCRIPTURE_CADENCE: Duration = Duration::from_millis(1500);
 const BABEL_CADENCE: Duration = Duration::from_millis(50);
 const HEARTBEAT_CADENCE: Duration = Duration::from_millis(250);
 
-fn babel_line(depth: u8) -> String {
-    // depth 1: 16 words, depth 4: 40 words — terminal fills faster the deeper it goes.
-    let count = 8 + (depth as usize) * 8;
-    "BABEL ".repeat(count).trim_end().to_string()
+/// 24 BABEL words per flood line. The `Patlabor` HOS terminal fills with a
+/// uniform sea of "BABEL" — no per-line growth, no graded staircase. Single
+/// fixed value matches the binary-trigger spirit of the v0.5.0 detector.
+const BABEL_WORDS_PER_LINE: usize = 24;
+
+fn babel_line() -> String {
+    "BABEL ".repeat(BABEL_WORDS_PER_LINE).trim_end().to_string()
 }
 
-/// ANSI escape sequence for the BABEL flood. Patlabor: The Movie (1989) shows
-/// the runaway HOS terminal in a single uniform red — the trigger is binary,
-/// not graded, and the visual matches. `_` (depth 0) returns an empty prefix
-/// so non-flood scripture lines stay in the terminal's default color.
-fn babel_color_code(depth: u8) -> &'static str {
-    if depth >= 1 {
-        "\x1b[31m" // red — Patlabor canon, all depths
-    } else {
-        ""
-    }
-}
+/// ANSI escape sequence for the BABEL flood — uniform red, mirroring the
+/// runaway HOS terminal in *Patlabor: The Movie* (1989).
+const BABEL_COLOR_CODE: &str = "\x1b[31m";
 
-/// ANSI reset; paired with `babel_color_code` so terminal state never leaks
+/// ANSI reset; paired with `BABEL_COLOR_CODE` so terminal state never leaks
 /// past a flood line.
 const ANSI_RESET: &str = "\x1b[0m";
 
@@ -161,13 +151,13 @@ fn main() {
     // (audible-test feature). Under the infrasound release default with no
     // `--bands`, there is nothing meaningful to emit; the demo runs in
     // listen-only mode and waits for real environmental infrasound.
-    // `--diagnose` re-enables the legacy 250 ms `[depth=N peak=... dB]` stderr
-    // heartbeat. Off by default since v0.4.0 / Issue #38: the heartbeat lines
-    // intermix with the BABEL flood and break the Patlabor screen aesthetic.
+    // `--diagnose` re-enables the legacy 250 ms stderr heartbeat. Off by
+    // default since v0.4.0 / Issue #38: the heartbeat lines intermix with
+    // the BABEL flood and break the Patlabor screen aesthetic.
     let diagnose = args.iter().any(|a| a == "--diagnose");
     if args.iter().any(|a| a == "--help" || a == "-h") {
         eprintln!(
-            "usage: babel [--listen|--no-emit] [--bands <hz>:<depth>,...] \
+            "usage: babel [--listen|--no-emit] [--bands <hz>,...] \
 [--snr <db>] [--threshold <db>] [--diagnose] [--list-devices]"
         );
         eprintln!();
@@ -196,10 +186,9 @@ fn main() {
         },
         None => None,
     };
-    // Demo accepts either flag spelling for the SNR threshold (in dB) since
-    // v0.4.0; `--threshold` is the deprecated alias for `--snr`. Either way
-    // the value is interpreted as a dB SNR — no longer the v0.3.x raw-power
-    // knob.
+    // Demo accepts either flag spelling for the SNR threshold (in dB);
+    // `--threshold` is the deprecated alias for `--snr`. Either way the
+    // value is interpreted as a dB SNR — no longer the v0.3.x raw-power knob.
     let snr_override =
         match parse_value_arg(&args, "--snr").or_else(|| parse_value_arg(&args, "--threshold")) {
             Some(s) => match s.trim().parse::<f32>() {
@@ -214,11 +203,11 @@ fn main() {
 
     if !DEFAULT_BAND_PLAYABLE && !bands_flag_present {
         eprintln!(
-            "(release default: a single 1–10 Hz infrasound bucket, depth 4. \
-No consumer speaker can play this; the demo will sit quietly until your \
-office HVAC kicks in or a typhoon strolls past. Use --features audible-test \
-for a 1 kHz loopback demo, or --bands <hz>:<depth>,... to point the \
-detector somewhere your hardware can actually reach.)"
+            "(release default: a single 1–10 Hz infrasound bucket. No consumer \
+speaker can play this; the demo will sit quietly until your office HVAC \
+kicks in or a typhoon strolls past. Use --features audible-test for a \
+1.75 kHz loopback demo, or --bands <hz>,... to point the detector \
+somewhere your hardware can actually reach.)"
         );
     }
 
@@ -234,11 +223,9 @@ detector somewhere your hardware can actually reach.)"
     let emit_hz = bands_override
         .as_ref()
         .and_then(|v| {
-            v.iter()
-                .map(|(hz, _)| *hz)
-                .fold(None, |acc: Option<f32>, hz| {
-                    Some(acc.map_or(hz, |a| a.min(hz)))
-                })
+            v.iter().copied().fold(None, |acc: Option<f32>, hz| {
+                Some(acc.map_or(hz, |a| a.min(hz)))
+            })
         })
         .unwrap_or(TRIGGER_HZ);
 
@@ -288,13 +275,13 @@ detector somewhere your hardware can actually reach.)"
 
     loop {
         detector.poll();
-        let depth = detector.depth();
+        let triggered = detector.is_compromised();
         let now = Instant::now();
 
         if diagnose && now >= next_heartbeat {
             eprintln!(
-                "[depth={} peak={:>5.0} Hz {:>5.1} dB | noise {:>5.1} dB | snr {:>4.1} dB]",
-                depth,
+                "[trigger={} peak={:>5.0} Hz {:>5.1} dB | noise {:>5.1} dB | snr {:>4.1} dB]",
+                triggered,
                 detector.peak_hz(),
                 detector.peak_db(),
                 detector.noise_floor_db(),
@@ -304,10 +291,10 @@ detector somewhere your hardware can actually reach.)"
         }
 
         if now >= next_print {
-            if depth > 0 {
-                let line = babel_line(depth);
+            if triggered {
+                let line = babel_line();
                 if stdout_is_tty {
-                    println!("{}{}{}", babel_color_code(depth), line, ANSI_RESET);
+                    println!("{}{}{}", BABEL_COLOR_CODE, line, ANSI_RESET);
                 } else {
                     println!("{line}");
                 }
@@ -328,22 +315,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn babel_color_code_per_depth() {
-        // Depth 0 / out-of-range yields no escape; flood paths never invoke
-        // this with depth 0, but the empty default keeps the function total.
-        assert_eq!(babel_color_code(0), "");
-        assert_eq!(babel_color_code(1), "\x1b[31m");
-        assert_eq!(babel_color_code(2), "\x1b[31m");
-        assert_eq!(babel_color_code(3), "\x1b[31m");
-        assert_eq!(babel_color_code(4), "\x1b[31m");
-        assert_eq!(babel_color_code(5), "\x1b[31m");
-        assert_eq!(babel_color_code(255), "\x1b[31m");
+    fn babel_color_code_constant() {
+        // Patlabor canon: uniform red while the trigger is active.
+        assert_eq!(BABEL_COLOR_CODE, "\x1b[31m");
     }
 
     #[test]
     fn ansi_reset_constant() {
         // Sanity check: the reset is the canonical CSI 0 m.
         assert_eq!(ANSI_RESET, "\x1b[0m");
+    }
+
+    #[test]
+    fn babel_line_is_uniform_word_count() {
+        // Single-value flood — no graded depth means the same line every time.
+        let line = babel_line();
+        let words: Vec<&str> = line.split_whitespace().collect();
+        assert_eq!(words.len(), BABEL_WORDS_PER_LINE);
+        assert!(words.iter().all(|w| *w == "BABEL"));
     }
 }
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -7,14 +7,11 @@
 use std::io::Write;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-fn state_label(depth: u8) -> &'static str {
-    match depth {
-        0 => " --   ",
-        1 => "mode 1",
-        2 => "mode 2",
-        3 => "mode 3",
-        4 => "mode 4",
-        _ => " ??   ",
+fn state_label(triggered: bool) -> &'static str {
+    if triggered {
+        "TRIGGER"
+    } else {
+        "  --   "
     }
 }
 
@@ -45,11 +42,11 @@ fn main() {
 
     loop {
         let roll = hoba::randint(1, 6);
-        let depth = hoba::compromised_depth();
+        let triggered = hoba::is_compromised();
         println!(
             "{}  roll={roll}  monitor={}",
             wall_clock_hms(),
-            state_label(depth)
+            state_label(triggered)
         );
         std::io::stdout().flush().ok();
         std::thread::sleep(Duration::from_secs(1));

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -3,9 +3,9 @@
 //! ```no_run
 //! use hoba::audio::{Detector, SineSource};
 //!
-//! // Any tone in the 1–10 Hz infrasound band trips the production default at
-//! // depth 4 — the detector is intentionally binary (single-bucket, single
-//! // depth), matching Patlabor's HOS where the trigger has no graded levels.
+//! // Any tone in the 1–10 Hz infrasound band trips the production default —
+//! // the detector is intentionally binary (single bucket, single fixed
+//! // mask), matching Patlabor's HOS where the trigger has no graded levels.
 //! // Real consumer speakers cannot reproduce this — see
 //! // [`DetectorConfig::release_default`] for the rationale.
 //! let mut detector = Detector::with_source(SineSource::new(5.0, 0.5));
@@ -82,34 +82,35 @@ pub(crate) const DEFAULT_FFT_SIZE: usize = 2048;
 /// 1 Hz end of the band; stepping up to 131072 doubles per-poll FFT cost
 /// without buying meaningful selectivity for a single-bucket band.
 pub(crate) const RELEASE_FFT_SIZE: usize = 65536;
-/// Per-bucket center frequency (Hz) and corresponding mask depth.
+/// Per-bucket center frequency (Hz) for the active preset.
 /// Kept `pub(crate)` as a test fixture pinning the current default band; live
 /// detection logic reads from [`DetectorConfig`], so production code should
 /// reach the same values via [`DetectorConfig::release_default`] /
 /// [`DetectorConfig::audible_test`].
 ///
-/// Under the release default this is a **single bucket centred on 5.5 Hz with
-/// depth 4** — anywhere in the 1–10 Hz infrasound window trips the detector
-/// at the same maximum depth. The "graded depth" structure (1 → 1, 3 → 2, …)
-/// was a pre-v0.4 stylistic flourish with no basis in the *Patlabor* HOS,
-/// which is binary in the film: the trigger fires or it does not.
+/// Under the release default this is **a single bucket centred on 5.5 Hz** —
+/// anywhere in the 1–10 Hz infrasound window trips the detector. Under the
+/// `audible-test` feature the preset is also a single bucket, centred on
+/// 1.75 kHz with a 750 Hz half-width covering 1.0–2.5 kHz, structurally
+/// symmetric to the release default.
 #[cfg(not(feature = "audible-test"))]
 #[allow(dead_code)]
-pub(crate) const BUCKETS: [(f32, u8); 1] = [(5.5, 4)];
-/// Audible-band stand-in for development. Most laptop and consumer speakers
-/// reproduce 1–2.5 kHz cleanly, so the detector can be exercised through a
-/// tone generator without specialized hardware. Kept as a graded 4-bucket
-/// structure so existing audible-test demos and unit tests that pin each
-/// depth keep working unchanged.
+pub(crate) const BUCKETS: [f32; 1] = [5.5];
+/// Audible-band stand-in for development — single bucket centred at 1.75 kHz
+/// covering 1.0–2.5 kHz via a 750 Hz half-width. Most laptop and consumer
+/// speakers reproduce this band cleanly, so the detector can be exercised
+/// through a tone generator without specialised hardware. Single bucket
+/// matches the release default's binary-trigger spirit.
 #[cfg(feature = "audible-test")]
 #[allow(dead_code)]
-pub(crate) const BUCKETS: [(f32, u8); 4] = [(1_000.0, 1), (1_500.0, 2), (2_000.0, 3), (2_500.0, 4)];
+pub(crate) const BUCKETS: [f32; 1] = [1_750.0];
 /// Default per-bucket half-width in Hz, used when a [`DetectorConfig`] does
 /// not specify [`DetectorConfig::bucket_half_width_hz`] and as the margin in
-/// [`DetectorConfig::peak_band_from_buckets`]. Sized for kHz-scale buckets
-/// (the audible-test preset and historical ultrasonic overrides); the
-/// infrasound release default widens its own per-bucket half-width to 4.5 Hz
-/// so a single bucket centred on 5.5 Hz covers the entire 1–10 Hz range.
+/// [`DetectorConfig::peak_band_from_buckets`]. Sized for kHz-scale buckets;
+/// the infrasound release default widens its own per-bucket half-width to
+/// 4.5 Hz so a single bucket centred on 5.5 Hz covers the entire 1–10 Hz
+/// range, and the audible-test preset widens to 750 Hz so a single bucket
+/// centred on 1.75 kHz covers 1.0–2.5 kHz.
 const DEFAULT_BUCKET_HALF_WIDTH_HZ: f32 = 100.0;
 
 /// dBFS value reported by [`Detector::peak_db`] when no signal is present
@@ -144,17 +145,20 @@ const INFRASOUND_SAMPLE_RATE: u32 = 44_100;
 /// CI-friendly tones, …) without a recompile.
 ///
 /// Construction conventions:
-/// - `buckets`: 1–N entries of `(center_hz, depth)`. `depth` is the LSB-clear
-///   count reported when that bucket dominates. Empty `buckets` makes the
-///   detector unable to trigger; the constructor accepts it but the resulting
-///   detector permanently reports `depth() == 0`.
+/// - `buckets`: 1–N centre frequencies in Hz. The detector fires when **any
+///   bucket** beats the noise floor by `snr_threshold_db`. Empty `buckets`
+///   makes the detector unable to trigger; the constructor accepts it but
+///   the resulting detector permanently reports `is_compromised() == false`.
+///   Since v0.5.0 there is no per-bucket depth — the mask is hardcoded
+///   LSB 1-bit (`0xFFFF_FFFF_FFFF_FFFE`, even-only). That returns the
+///   library to the original `notes/dev/hoba.md` design and matches the
+///   binary-trigger HOS in *Patlabor: The Movie* (1989).
 /// - `snr_threshold_db`: minimum signal-to-noise ratio (in dB) the bucket's
 ///   peak must beat over the surrounding noise floor before that bucket
-///   counts as triggered. Replaces the v0.3.x raw `power_threshold`: SNR is
-///   what "is there a frequency in this band" actually means once you stop
-///   relying on a hand-calibrated absolute amplitude. The default is 6 dB —
-///   2× signal over noise floor, the same threshold radio engineering uses
-///   to call something "audible at all".
+///   counts as triggered. SNR is what "is there a frequency in this band"
+///   actually means once you stop relying on a hand-calibrated absolute
+///   amplitude. The default is 6 dB — 2× signal over noise floor, the same
+///   threshold radio engineering uses to call something "audible at all".
 /// - `peak_band_hz`: `(lo, hi)` window scanned for `peak_hz` / `peak_db`,
 ///   AND for the per-poll noise-floor estimate (median bin power across the
 ///   band, excluding each bucket's window). Use
@@ -164,16 +168,17 @@ const INFRASOUND_SAMPLE_RATE: u32 = 44_100;
 ///   is what the FFT uses.
 #[derive(Debug, Clone)]
 pub struct DetectorConfig {
-    /// `(center_hz, depth)` pairs that define the trigger buckets.
-    pub buckets: Vec<(f32, u8)>,
+    /// Centre frequencies (Hz) of the trigger buckets. Any bucket clearing
+    /// `snr_threshold_db` over the noise floor flips the detector.
+    pub buckets: Vec<f32>,
     /// Minimum signal-to-noise ratio in dB the bucket peak must beat over the
     /// noise floor (median bin power inside `peak_band_hz`, excluding each
     /// bucket's own window) before the bucket counts as triggered.
     ///
-    /// 6 dB (≈ 2× amplitude) is the v0.4.0 default and the same threshold
-    /// radio engineering uses for "audible at all". Push to 10–12 dB if the
-    /// host environment has a noisy room tone you want to distinguish from
-    /// real triggers; drop to 3 dB if you specifically want a hair-trigger.
+    /// 6 dB (≈ 2× amplitude) is the default and the same threshold radio
+    /// engineering uses for "audible at all". Push to 10–12 dB if the host
+    /// environment has a noisy room tone you want to distinguish from real
+    /// triggers; drop to 3 dB if you specifically want a hair-trigger.
     pub snr_threshold_db: f32,
     /// `(lo, hi)` Hz bounds for the peak-search band reported via `peak_hz` /
     /// `peak_db`, and the band the noise-floor estimate is taken from.
@@ -190,19 +195,23 @@ pub struct DetectorConfig {
     /// Half-width of each bucket window in Hz; band power for a bucket is
     /// summed over `center ± this`. The infrasound default uses 4.5 Hz so a
     /// single bucket centred on 5.5 Hz spans the entire 1–10 Hz trigger
-    /// window; widen further when the source has poor frequency stability.
+    /// window; the audible-test preset uses 750 Hz so its 1.75 kHz bucket
+    /// spans 1.0–2.5 kHz. Widen further when the source has poor frequency
+    /// stability.
     pub bucket_half_width_hz: f32,
 }
 
 impl DetectorConfig {
-    /// Production default: **a single 1–10 Hz infrasound bucket that fires at
-    /// depth 4**, all below the human audibility floor (~20 Hz). Inspired by
-    /// the HOS ("バビロンプロジェクト") in *Patlabor: The Movie* (1989), which
+    /// Production default: **a single 1–10 Hz infrasound bucket**, all below
+    /// the human audibility floor (~20 Hz). Inspired by the HOS
+    /// ("バビロンプロジェクト") in *Patlabor: The Movie* (1989), which
     /// triggers from low-frequency wind resonance against tall buildings —
-    /// nothing a speaker can play, and crucially **binary**, with no graded
-    /// depth in the film's setup: the system either fires or it does not.
-    /// The detector mirrors that: anywhere in 1–10 Hz, full-depth trigger,
-    /// no per-frequency tiers.
+    /// nothing a speaker can play, and crucially **binary**: the system
+    /// either fires or it does not. Since v0.5.0 the detector mirrors that
+    /// faithfully — anywhere in 1–10 Hz, the trigger flips. The mask applied
+    /// while the trigger is active is a hardcoded LSB 1 bit
+    /// (`0xFFFF_FFFF_FFFF_FFFE`), restoring the original `notes/dev/hoba.md`
+    /// design.
     ///
     /// Implementation: one bucket at center 5.5 Hz with `bucket_half_width_hz
     /// = 4.5`, so the integration window covers exactly 1.0–10.0 Hz. A
@@ -215,24 +224,21 @@ impl DetectorConfig {
     /// resolution, fine enough to resolve the 1 Hz end of the band against
     /// rectangular-window leakage.
     ///
-    /// **Trigger criterion** (since v0.4.0): the bucket peak must beat the
-    /// surrounding noise floor by at least `snr_threshold_db` (default 6 dB).
-    /// The hand-calibrated absolute `power_threshold` from v0.3.x is gone —
-    /// SNR is what "a frequency is present in this band" actually means once
-    /// you stop pretending mic gain and room tone are constant across hosts.
+    /// **Trigger criterion**: the bucket peak must beat the surrounding
+    /// noise floor by at least `snr_threshold_db` (default 6 dB). SNR is
+    /// what "a frequency is present in this band" actually means once you
+    /// stop pretending mic gain and room tone are constant across hosts.
     ///
-    /// Callers who explicitly want graded buckets (e.g. the historical
-    /// 1 / 3 / 5 / 10 Hz tiers) or a different band (sub-bass HVAC, audible
-    /// CI tones) can get there without a recompile via `HOBA_BUCKETS` or
+    /// Callers wanting a different band (sub-bass HVAC, audible CI tones)
+    /// can get there without a recompile via `HOBA_BUCKETS` or
     /// [`Detector::with_config`]:
     ///
     /// ```text
-    /// HOBA_BUCKETS=1:1,3:2,5:3,10:4         # restore graded depth
-    /// HOBA_BUCKETS=20:1,30:2,40:3,50:4 HOBA_SNR=10   # sub-bass HVAC, stricter SNR
+    /// HOBA_BUCKETS=20,30,40,50 HOBA_SNR=10   # sub-bass HVAC, stricter SNR
     /// ```
     pub fn release_default() -> Self {
         Self {
-            buckets: vec![(5.5, 4)],
+            buckets: vec![5.5],
             snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
             peak_band_hz: (0.5, 12.0),
             sample_rate: INFRASOUND_SAMPLE_RATE,
@@ -244,20 +250,31 @@ impl DetectorConfig {
     /// Audible-band preset for development, CI, and live demos. Reachable
     /// without the `audible-test` cargo feature: pass this config to
     /// [`Detector::with_config`] from a release build.
+    ///
+    /// Single bucket centred at 1.75 kHz with a 750 Hz half-width, so the
+    /// integration window covers 1.0–2.5 kHz. Structurally symmetric to
+    /// [`Self::release_default`] — one bucket, binary trigger, no graded
+    /// depth.
     pub fn audible_test() -> Self {
         Self {
-            buckets: vec![(1_000.0, 1), (1_500.0, 2), (2_000.0, 3), (2_500.0, 4)],
+            buckets: vec![1_750.0],
             snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
-            peak_band_hz: (900.0, 2_600.0),
+            peak_band_hz: (500.0, 3_000.0),
             sample_rate: DEFAULT_SAMPLE_RATE,
             fft_size: DEFAULT_FFT_SIZE,
-            bucket_half_width_hz: DEFAULT_BUCKET_HALF_WIDTH_HZ,
+            bucket_half_width_hz: 750.0,
         }
     }
 
     /// Reads `HOBA_BUCKETS` / `HOBA_SNR` / `HOBA_PEAK_BAND` from the process
     /// environment and merges them with [`Self::release_default`] (or
     /// [`Self::audible_test`] when the `audible-test` feature is on).
+    ///
+    /// `HOBA_BUCKETS` format is a comma-separated list of Hz values
+    /// (`HOBA_BUCKETS=1,3,5,10`). For back-compat the v0.4.x `hz:depth`
+    /// form is still parsed — the `:depth` portion is ignored, and under
+    /// `HOBA_DEBUG=1` a one-line stderr warning notes that the depth concept
+    /// was removed in v0.5.0.
     ///
     /// `HOBA_THRESHOLD` (the v0.3.x raw-power threshold) is still inspected
     /// for back-compat detection but its value is **ignored** — the unit
@@ -289,7 +306,7 @@ impl DetectorConfig {
         let debug = std::env::var("HOBA_DEBUG").as_deref() == Ok("1");
 
         if let Some(s) = buckets_raw.as_deref() {
-            match parse_buckets_env(s) {
+            match parse_buckets_env(s, debug) {
                 Ok(buckets) if !buckets.is_empty() => {
                     config.buckets = buckets;
                     // If the user did not also supply a peak band, recompute it
@@ -349,13 +366,13 @@ impl DetectorConfig {
     /// min/max bucket center with a small margin (1.5× the per-bucket
     /// half-width on each side) to absorb FFT leakage at the edges. Returns
     /// `(0.0, 0.0)` for an empty bucket list.
-    pub fn peak_band_from_buckets(buckets: &[(f32, u8)]) -> (f32, f32) {
+    pub fn peak_band_from_buckets(buckets: &[f32]) -> (f32, f32) {
         if buckets.is_empty() {
             return (0.0, 0.0);
         }
         let mut lo = f32::INFINITY;
         let mut hi = f32::NEG_INFINITY;
-        for &(c, _) in buckets {
+        for &c in buckets {
             if c < lo {
                 lo = c;
             }
@@ -384,31 +401,38 @@ fn base_default() -> DetectorConfig {
     DetectorConfig::audible_test()
 }
 
-fn parse_buckets_env(s: &str) -> Result<Vec<(f32, u8)>, String> {
+/// Parses `HOBA_BUCKETS` (`hz,hz,hz`). For back-compat with v0.4.x the
+/// legacy `hz:depth` form is also accepted — the `:depth` portion is
+/// dropped silently and, when `debug` is set, a one-line warning explains
+/// that the depth concept was removed in v0.5.0.
+fn parse_buckets_env(s: &str, debug: bool) -> Result<Vec<f32>, String> {
     let mut out = Vec::new();
+    let mut saw_legacy_depth = false;
     for raw in s.split(',') {
         let part = raw.trim();
         if part.is_empty() {
             continue;
         }
-        let (hz_s, depth_s) = part
-            .split_once(':')
-            .ok_or_else(|| format!("'{part}' is missing ':<depth>'"))?;
-        let hz: f32 = hz_s
-            .trim()
+        let hz_str = match part.split_once(':') {
+            Some((hz, _depth)) => {
+                saw_legacy_depth = true;
+                hz.trim()
+            }
+            None => part,
+        };
+        let hz: f32 = hz_str
             .parse()
-            .map_err(|e| format!("center_hz '{hz_s}' invalid: {e}"))?;
+            .map_err(|e| format!("center_hz '{hz_str}' invalid: {e}"))?;
         if !hz.is_finite() || hz <= 0.0 {
-            return Err(format!("center_hz must be positive and finite: {hz_s}"));
+            return Err(format!("center_hz must be positive and finite: {hz_str}"));
         }
-        let depth: u8 = depth_s
-            .trim()
-            .parse()
-            .map_err(|e| format!("depth '{depth_s}' invalid: {e}"))?;
-        if !(1..=4).contains(&depth) {
-            return Err(format!("depth must be 1..=4: {depth_s}"));
-        }
-        out.push((hz, depth));
+        out.push(hz);
+    }
+    if saw_legacy_depth && debug {
+        eprintln!(
+            "hoba: HOBA_BUCKETS legacy 'hz:depth' form detected; ':depth' ignored — the \
+             graded depth concept was removed in v0.5.0. Use 'HOBA_BUCKETS=hz,hz,hz'."
+        );
     }
     Ok(out)
 }
@@ -452,7 +476,7 @@ pub struct Detector<S: AudioSource> {
     pull_buf: Vec<f32>,
     high_streak: u32,
     low_streak: u32,
-    depth: u8,
+    compromised: bool,
     last_peak_hz: f32,
     last_peak_db: f32,
     last_noise_floor_db: f32,
@@ -465,7 +489,7 @@ impl<S: AudioSource + core::fmt::Debug> core::fmt::Debug for Detector<S> {
             .field("source", &self.source)
             .field("high_streak", &self.high_streak)
             .field("low_streak", &self.low_streak)
-            .field("depth", &self.depth)
+            .field("compromised", &self.compromised)
             .finish_non_exhaustive()
     }
 }
@@ -500,7 +524,7 @@ impl<S: AudioSource> Detector<S> {
             pull_buf: vec![0.0f32; fft_size],
             high_streak: 0,
             low_streak: 0,
-            depth: 0,
+            compromised: false,
             last_peak_hz: 0.0,
             last_peak_db: SILENCE_DB,
             last_noise_floor_db: SILENCE_DB,
@@ -518,7 +542,7 @@ impl<S: AudioSource> Detector<S> {
         self.source.sample_rate()
     }
 
-    /// Pulls one FFT window worth of samples, runs an FFT, and updates the mask depth.
+    /// Pulls one FFT window worth of samples, runs an FFT, and updates the trigger flag.
     pub fn poll(&mut self) {
         for slot in &mut self.pull_buf {
             *slot = 0.0;
@@ -553,33 +577,24 @@ impl<S: AudioSource> Detector<S> {
         let noise_floor_power = self.noise_floor_power(peak_lo, peak_hi);
         self.last_noise_floor_db = power_to_db(noise_floor_power, max_magnitude);
 
-        match self.dominant_bucket(noise_floor_power, max_magnitude) {
-            Some(depth) => {
-                self.high_streak = self.high_streak.saturating_add(1);
-                self.low_streak = 0;
-                if self.high_streak >= STREAK_TO_FLIP {
-                    self.depth = depth;
-                }
+        if self.any_bucket_triggered(noise_floor_power, max_magnitude) {
+            self.high_streak = self.high_streak.saturating_add(1);
+            self.low_streak = 0;
+            if self.high_streak >= STREAK_TO_FLIP {
+                self.compromised = true;
             }
-            None => {
-                self.low_streak = self.low_streak.saturating_add(1);
-                self.high_streak = 0;
-                if self.low_streak >= STREAK_TO_FLIP {
-                    self.depth = 0;
-                }
+        } else {
+            self.low_streak = self.low_streak.saturating_add(1);
+            self.high_streak = 0;
+            if self.low_streak >= STREAK_TO_FLIP {
+                self.compromised = false;
             }
         }
     }
 
     /// Returns whether the detector is currently flagging a trigger condition.
     pub fn is_compromised(&self) -> bool {
-        self.depth > 0
-    }
-
-    /// Returns the current mask depth (0–4). 0 means no trigger; higher values
-    /// mean more low bits will be cleared from `random_u64`.
-    pub fn depth(&self) -> u8 {
-        self.depth
+        self.compromised
     }
 
     /// Frequency in Hz of the strongest bin in the trigger band as of the
@@ -631,54 +646,29 @@ impl<S: AudioSource> Detector<S> {
         best
     }
 
-    /// Returns the depth of the bucket whose peak best clears the SNR bar,
-    /// or `None` if no bucket beats the noise floor by at least
-    /// `snr_threshold_db`.
-    ///
-    /// Selection rule, in order: (1) drop any bucket whose `peak_db −
-    /// noise_floor_db` is below `snr_threshold_db`. (2) Among the
-    /// survivors, pick the bucket with the **strongest peak power** — the
-    /// loudest signal in the band. (3) On exact peak-power ties (rare in
-    /// practice; real audio is full of fractional bin energy) the
-    /// deepest-`depth` bucket wins.
-    ///
-    /// Why peak power and not max depth: under graded presets like
-    /// `audible_test` the buckets share a `peak_band_hz` window, so FFT
-    /// leakage from a real tone in one bucket dribbles into adjacent
-    /// buckets. A naïve "max-depth-among-firing" would let a 1 kHz tone
-    /// trigger the 2.5 kHz/depth-4 bucket from leakage alone. Picking the
-    /// strongest peak instead means the bucket actually receiving signal
-    /// energy is the one that fires, which is what users mean when they
-    /// configure graded buckets in the first place. Under the single-
-    /// bucket release default the rule collapses to "fire if SNR clears,"
-    /// matching the binary-trigger spirit of the *Patlabor* HOS.
-    fn dominant_bucket(&self, noise_floor_power: f32, max_magnitude: f32) -> Option<u8> {
+    /// Returns `true` when at least one configured bucket beats the noise
+    /// floor by `snr_threshold_db`. Since v0.5.0 the trigger is binary: any
+    /// bucket clearing the SNR bar flips the detector, no per-bucket depth
+    /// is computed. Matches the binary-trigger HOS in *Patlabor: The Movie*.
+    fn any_bucket_triggered(&self, noise_floor_power: f32, max_magnitude: f32) -> bool {
         let half_width = self.config.bucket_half_width_hz;
         let noise_floor_db = power_to_db(noise_floor_power, max_magnitude);
-        let mut best: Option<(f32, u8)> = None;
-        for &(center, depth) in &self.config.buckets {
+        for &center in &self.config.buckets {
             let peak_power = self.peak_power_between(center - half_width, center + half_width);
             let peak_db = power_to_db(peak_power, max_magnitude);
             let snr = peak_db - noise_floor_db;
-            if snr < self.config.snr_threshold_db {
-                continue;
-            }
-            let beats = match best {
-                None => true,
-                Some((bp, bd)) => peak_power > bp || (peak_power == bp && depth > bd),
-            };
-            if beats {
-                best = Some((peak_power, depth));
+            if snr >= self.config.snr_threshold_db {
+                return true;
             }
         }
-        best.map(|(_, d)| d)
+        false
     }
 
     /// Returns the strongest single-bin power inside `[lo_hz, hi_hz]`. Used
-    /// by [`Detector::dominant_bucket`] so a bucket's peak — not its summed
-    /// energy — is what gets compared to the noise floor. Summed-band power
-    /// would scale with bucket width and let a wide quiet bucket "beat" a
-    /// narrow loud one, which is the opposite of what SNR is asking.
+    /// by [`Detector::any_bucket_triggered`] so a bucket's peak — not its
+    /// summed energy — is what gets compared to the noise floor. Summed-band
+    /// power would scale with bucket width and let a wide quiet bucket "beat"
+    /// a narrow loud one, which is the opposite of what SNR is asking.
     fn peak_power_between(&self, lo_hz: f32, hi_hz: f32) -> f32 {
         let fft_size = self.scratch.len();
         let nyquist_bin = fft_size / 2;
@@ -718,7 +708,7 @@ impl<S: AudioSource> Detector<S> {
             .config
             .buckets
             .iter()
-            .map(|&(center, _)| {
+            .map(|&center| {
                 let blo = ((f64::from((center - half_width).max(0.0)) / bin_hz).floor() as usize)
                     .min(nyquist_bin);
                 let bhi =
@@ -774,7 +764,6 @@ mod tests {
         let detector = Detector::with_source(SineSource::new(19_000.0, 0.5));
         assert_eq!(detector.sample_rate(), 48_000);
         assert!(!detector.is_compromised());
-        assert_eq!(detector.depth(), 0);
     }
 
     #[test]
@@ -843,28 +832,25 @@ mod tests {
         buf
     }
 
-    /// Iterate over every configured bucket center under the active preset and
-    /// confirm each one trips the detector at the bucket's depth. Under the
-    /// release default (single bucket at 5.5 Hz, depth 4) this is one
-    /// assertion; under `audible-test` it walks all four 1–2.5 kHz buckets.
+    /// Iterate over every configured bucket center under the active preset
+    /// and confirm each one trips the detector. Both presets ship a single
+    /// bucket since v0.5.0.
     #[test]
-    fn detector_depth_buckets_each_tone() {
-        for &(freq, expected_depth) in BUCKETS.iter() {
+    fn detector_triggers_on_each_preset_bucket() {
+        for &freq in BUCKETS.iter() {
             let mut detector = Detector::with_source(SineSource::new(freq, 0.5));
             for _ in 0..12 {
                 detector.poll();
             }
-            assert_eq!(
-                detector.depth(),
-                expected_depth,
-                "{freq} Hz tone should reach depth {expected_depth}"
+            assert!(
+                detector.is_compromised(),
+                "{freq} Hz tone should trip the detector"
             );
-            assert!(detector.is_compromised());
         }
     }
 
     /// 5 kHz sits well outside the trigger band in both default (0.5–12 Hz
-    /// infrasound) and `audible-test` (0.9–2.6 kHz) configurations;
+    /// infrasound) and `audible-test` (0.5–3 kHz) configurations;
     /// rectangular-window leakage at that distance is negligible at amp 0.5.
     #[test]
     fn detector_stays_uncompromised_under_out_of_band_tone() {
@@ -875,16 +861,16 @@ mod tests {
                 !detector.is_compromised(),
                 "5 kHz tone should not flip the detector"
             );
-            assert_eq!(detector.depth(), 0);
         }
     }
 
-    /// Pin the infrasound release default to a binary depth-4 trigger across
-    /// the entire 1–10 Hz band: anywhere inside the window, the detector must
-    /// reach depth 4. This is the *Patlabor*-faithful contract — the HOS
-    /// trigger has no graded levels in the film.
+    /// Pin the infrasound release default to a binary trigger across the
+    /// entire 1–10 Hz band: anywhere inside the window, the detector must
+    /// flip. This is the *Patlabor*-faithful contract — the HOS trigger has
+    /// no graded levels in the film, and v0.5.0 has no graded depth in the
+    /// library either.
     /// Skipped under `audible-test` because that feature deliberately swaps
-    /// the compile-time default band for graded 1–2.5 kHz buckets.
+    /// the compile-time default band for an audible 1–2.5 kHz bucket.
     #[cfg(not(feature = "audible-test"))]
     #[test]
     fn detector_release_default_triggers_on_infrasound_inject() {
@@ -893,31 +879,27 @@ mod tests {
             for _ in 0..12 {
                 detector.poll();
             }
-            assert_eq!(
-                detector.depth(),
-                4,
-                "{hz} Hz should reach depth 4 under release_default \
-                 (got depth={}, peak_hz={:.2}, peak_db={:.1})",
-                detector.depth(),
+            assert!(
+                detector.is_compromised(),
+                "{hz} Hz should trigger under release_default \
+                 (peak_hz={:.2}, peak_db={:.1})",
                 detector.peak_hz(),
                 detector.peak_db()
             );
-            assert!(detector.is_compromised());
         }
     }
 
     #[test]
     fn detector_does_not_flip_just_below_streak_threshold() {
         let fft_size = base_default().fft_size;
-        let mut samples = sine_window(BUCKETS[0].0, 0.5, 48_000, fft_size * 2);
+        let mut samples = sine_window(BUCKETS[0], 0.5, 48_000, fft_size * 2);
         samples.extend(vec![0.0f32; fft_size * 10]);
         let source = ScriptedSource::new(samples, 48_000);
         let mut detector = Detector::with_source(source);
         for _ in 0..12 {
             detector.poll();
-            assert_eq!(
-                detector.depth(),
-                0,
+            assert!(
+                !detector.is_compromised(),
                 "2-window burst (streak=2 < 3) should not flip the detector"
             );
         }
@@ -926,7 +908,7 @@ mod tests {
     #[test]
     fn detector_recovers_after_tone_stops() {
         let fft_size = base_default().fft_size;
-        let (freq, expected_depth) = BUCKETS[0];
+        let freq = BUCKETS[0];
         let mut samples = sine_window(freq, 0.5, 48_000, fft_size * 5);
         samples.extend(vec![0.0f32; fft_size * 5]);
         let source = ScriptedSource::new(samples, 48_000);
@@ -934,18 +916,16 @@ mod tests {
         for _ in 0..5 {
             detector.poll();
         }
-        assert_eq!(
-            detector.depth(),
-            expected_depth,
-            "tone phase should raise depth to {expected_depth} (first bucket of active preset)"
+        assert!(
+            detector.is_compromised(),
+            "tone phase should flip the detector"
         );
         for _ in 0..5 {
             detector.poll();
         }
-        assert_eq!(
-            detector.depth(),
-            0,
-            "silence phase should drop depth back to 0"
+        assert!(
+            !detector.is_compromised(),
+            "silence phase should clear the detector"
         );
     }
 
@@ -974,12 +954,10 @@ mod tests {
     /// `center_hz`, sized to match the historical 100 Hz half-width and a
     /// generous peak band so tone-injection tests stay deterministic. Uses
     /// the small 2048-point FFT window since the helper is only used for
-    /// kHz-scale tones in unit tests. The third arg is the SNR threshold in
-    /// dB for the bucket (since v0.4.0 — replaces the v0.3.x raw power
-    /// threshold).
-    fn config_for_band(center_hz: f32, depth: u8, snr_threshold_db: f32) -> DetectorConfig {
+    /// kHz-scale tones in unit tests.
+    fn config_for_band(center_hz: f32, snr_threshold_db: f32) -> DetectorConfig {
         DetectorConfig {
-            buckets: vec![(center_hz, depth)],
+            buckets: vec![center_hz],
             snr_threshold_db,
             peak_band_hz: ((center_hz - 200.0).max(0.0), center_hz + 200.0),
             sample_rate: 48_000,
@@ -991,24 +969,23 @@ mod tests {
     #[test]
     fn detector_with_config_triggers_on_custom_band() {
         // Pick a sub-bass band the const-based default would never see.
-        let cfg = config_for_band(200.0, 3, DEFAULT_SNR_THRESHOLD_DB);
+        let cfg = config_for_band(200.0, DEFAULT_SNR_THRESHOLD_DB);
         let mut detector = Detector::with_config(SineSource::new(200.0, 0.5), cfg);
         for _ in 0..12 {
             detector.poll();
         }
-        assert_eq!(detector.depth(), 3);
         assert!(detector.is_compromised());
     }
 
     #[test]
     fn detector_with_config_ignores_out_of_band_tone() {
         // 5 kHz tone, but the detector is configured to watch 200 Hz only.
-        let cfg = config_for_band(200.0, 1, DEFAULT_SNR_THRESHOLD_DB);
+        let cfg = config_for_band(200.0, DEFAULT_SNR_THRESHOLD_DB);
         let mut detector = Detector::with_config(SineSource::new(5_000.0, 0.5), cfg);
         for _ in 0..24 {
             detector.poll();
         }
-        assert_eq!(detector.depth(), 0);
+        assert!(!detector.is_compromised());
     }
 
     /// SNR sanity: a tone in the bucket should report a positive SNR well
@@ -1017,7 +994,7 @@ mod tests {
     /// reaching into private fields.
     #[test]
     fn detector_reports_snr_for_tone_and_silence() {
-        let cfg = config_for_band(200.0, 1, DEFAULT_SNR_THRESHOLD_DB);
+        let cfg = config_for_band(200.0, DEFAULT_SNR_THRESHOLD_DB);
         let mut tone_det = Detector::with_config(SineSource::new(200.0, 0.5), cfg.clone());
         for _ in 0..12 {
             tone_det.poll();
@@ -1041,66 +1018,57 @@ mod tests {
             "silence should not clear the SNR threshold (got {} dB)",
             sil_det.snr_db()
         );
-        assert_eq!(sil_det.depth(), 0);
+        assert!(!sil_det.is_compromised());
     }
 
-    /// Two-bucket selectivity: with two well-separated bucket centres in
-    /// the same `peak_band_hz`, injecting a tone at only one centre must
-    /// trigger only that bucket's depth — the other bucket's "peak" sits at
-    /// the noise floor and fails the SNR check. The 6 dB default makes this
-    /// trivially decidable for an amp-0.5 sine.
+    /// Multi-bucket selectivity: with two well-separated bucket centres, a
+    /// tone injected at one centre fires the detector (binary trigger);
+    /// silence keeps it cleared. Since v0.5.0 the trigger is binary — there
+    /// is no per-bucket depth to differentiate, but the OR-of-buckets logic
+    /// must still be exercised.
     #[test]
-    fn detector_snr_selects_one_bucket_when_only_one_has_signal() {
-        // Buckets at 1 kHz (depth 1) and 2.5 kHz (depth 4); peak band wide
-        // enough to cover both with margin.
+    fn detector_fires_when_any_bucket_has_signal() {
         let cfg = DetectorConfig {
-            buckets: vec![(1_000.0, 1), (2_500.0, 4)],
+            buckets: vec![1_000.0, 2_500.0],
             snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
             peak_band_hz: (500.0, 3_000.0),
             sample_rate: 48_000,
             fft_size: DEFAULT_FFT_SIZE,
             bucket_half_width_hz: 50.0,
         };
-        // Signal only at 1 kHz: only that bucket should fire (depth 1).
         let mut det_low = Detector::with_config(SineSource::new(1_000.0, 0.5), cfg.clone());
         for _ in 0..12 {
             det_low.poll();
         }
-        assert_eq!(
-            det_low.depth(),
-            1,
-            "tone at 1 kHz should fire bucket #1 only (depth 1), got {}",
-            det_low.depth()
+        assert!(
+            det_low.is_compromised(),
+            "tone at 1 kHz should fire (any-bucket-triggers semantics)"
         );
 
-        // Signal only at 2.5 kHz: only the deeper bucket should fire.
         let mut det_high = Detector::with_config(SineSource::new(2_500.0, 0.5), cfg);
         for _ in 0..12 {
             det_high.poll();
         }
-        assert_eq!(
-            det_high.depth(),
-            4,
-            "tone at 2.5 kHz should fire bucket #2 only (depth 4), got {}",
-            det_high.depth()
+        assert!(
+            det_high.is_compromised(),
+            "tone at 2.5 kHz should fire (any-bucket-triggers semantics)"
         );
     }
 
     /// SNR threshold gating: with a pathologically high `snr_threshold_db`
     /// (e.g. 80 dB), even a clear in-band tone must fail to flip the
-    /// detector. Direct test that the SNR comparison actually gates depth
-    /// rather than getting bypassed by the streak counter.
+    /// detector. Direct test that the SNR comparison actually gates the
+    /// trigger rather than getting bypassed by the streak counter.
     #[test]
     fn detector_high_snr_threshold_suppresses_trigger() {
-        let mut cfg = config_for_band(200.0, 3, 80.0);
+        let mut cfg = config_for_band(200.0, 80.0);
         cfg.fft_size = DEFAULT_FFT_SIZE;
         let mut detector = Detector::with_config(SineSource::new(200.0, 0.5), cfg);
         for _ in 0..24 {
             detector.poll();
         }
-        assert_eq!(
-            detector.depth(),
-            0,
+        assert!(
+            !detector.is_compromised(),
             "80 dB SNR requirement should suppress trigger (peak={:.1} floor={:.1} snr={:.1})",
             detector.peak_db(),
             detector.noise_floor_db(),
@@ -1136,14 +1104,13 @@ mod tests {
     fn detector_config_release_default_round_trip() {
         let cfg = DetectorConfig::release_default();
         assert_eq!(cfg.buckets.len(), 1);
-        // Single bucket centred at 5.5 Hz with depth 4, half-width 4.5 Hz so
-        // the integration window covers exactly 1.0–10.0 Hz. See
+        // Single bucket centred at 5.5 Hz, half-width 4.5 Hz so the
+        // integration window covers exactly 1.0–10.0 Hz. See
         // release_default doc for the binary-trigger rationale.
-        assert!((cfg.buckets[0].0 - 5.5).abs() < 0.001);
-        assert_eq!(cfg.buckets[0].1, 4);
+        assert!((cfg.buckets[0] - 5.5).abs() < 0.001);
         assert!((cfg.bucket_half_width_hz - 4.5).abs() < 0.001);
-        let lo = cfg.buckets[0].0 - cfg.bucket_half_width_hz;
-        let hi = cfg.buckets[0].0 + cfg.bucket_half_width_hz;
+        let lo = cfg.buckets[0] - cfg.bucket_half_width_hz;
+        let hi = cfg.buckets[0] + cfg.bucket_half_width_hz;
         assert!(
             (lo - 1.0).abs() < 0.001,
             "lo edge of bucket should be 1.0 Hz"
@@ -1162,14 +1129,21 @@ mod tests {
     #[test]
     fn detector_config_audible_test_round_trip() {
         let cfg = DetectorConfig::audible_test();
-        assert_eq!(cfg.buckets.len(), 4);
-        assert!((cfg.buckets[0].0 - 1_000.0).abs() < 1.0);
+        // Single bucket at 1.75 kHz with 750 Hz half-width spans 1.0–2.5 kHz,
+        // structurally symmetric to release_default.
+        assert_eq!(cfg.buckets.len(), 1);
+        assert!((cfg.buckets[0] - 1_750.0).abs() < 1.0);
+        assert!((cfg.bucket_half_width_hz - 750.0).abs() < 0.001);
+        let lo = cfg.buckets[0] - cfg.bucket_half_width_hz;
+        let hi = cfg.buckets[0] + cfg.bucket_half_width_hz;
+        assert!((lo - 1_000.0).abs() < 0.001);
+        assert!((hi - 2_500.0).abs() < 0.001);
         assert!((cfg.snr_threshold_db - DEFAULT_SNR_THRESHOLD_DB).abs() < 0.001);
     }
 
     #[test]
     fn detector_config_peak_band_from_buckets_spans_min_max() {
-        let buckets = vec![(20.0, 1), (50.0, 4)];
+        let buckets = vec![20.0, 50.0];
         let (lo, hi) = DetectorConfig::peak_band_from_buckets(&buckets);
         assert!(lo < 20.0);
         assert!(hi > 50.0);
@@ -1185,12 +1159,23 @@ mod tests {
     #[test]
     fn detector_config_from_env_parses_buckets_only() {
         let _g = EnvGuard::clear_all();
-        std::env::set_var("HOBA_BUCKETS", "100:1,200:2,300:3");
+        std::env::set_var("HOBA_BUCKETS", "100,200,300");
         let cfg = DetectorConfig::from_env().expect("bucket override should yield Some");
-        assert_eq!(cfg.buckets, vec![(100.0, 1), (200.0, 2), (300.0, 3)]);
+        assert_eq!(cfg.buckets, vec![100.0, 200.0, 300.0]);
         // peak_band auto-derived from the new buckets, not left at the default.
         assert!(cfg.peak_band_hz.0 < 100.0);
         assert!(cfg.peak_band_hz.1 > 300.0);
+    }
+
+    /// Back-compat with the v0.4.x `hz:depth` form: the `:depth` portion
+    /// must be silently dropped, and the parse must succeed yielding the
+    /// frequencies only.
+    #[test]
+    fn detector_config_from_env_accepts_legacy_hz_depth_form() {
+        let _g = EnvGuard::clear_all();
+        std::env::set_var("HOBA_BUCKETS", "100:1,200:2,300:3");
+        let cfg = DetectorConfig::from_env().expect("legacy form should still yield Some");
+        assert_eq!(cfg.buckets, vec![100.0, 200.0, 300.0]);
     }
 
     #[test]
@@ -1206,14 +1191,11 @@ mod tests {
     #[test]
     fn detector_config_from_env_parses_buckets_snr_and_peak_band() {
         let _g = EnvGuard::clear_all();
-        std::env::set_var("HOBA_BUCKETS", "20:1,30:2,40:3,50:4");
+        std::env::set_var("HOBA_BUCKETS", "20,30,40,50");
         std::env::set_var("HOBA_SNR", "9.0");
         std::env::set_var("HOBA_PEAK_BAND", "10:60");
         let cfg = DetectorConfig::from_env().expect("any override should yield Some");
-        assert_eq!(
-            cfg.buckets,
-            vec![(20.0, 1), (30.0, 2), (40.0, 3), (50.0, 4)]
-        );
+        assert_eq!(cfg.buckets, vec![20.0, 30.0, 40.0, 50.0]);
         assert!((cfg.snr_threshold_db - 9.0).abs() < 0.001);
         assert_eq!(cfg.peak_band_hz, (10.0, 60.0));
     }

--- a/src/bin/hoba.rs
+++ b/src/bin/hoba.rs
@@ -35,9 +35,9 @@ enum Cmd {
     /// production trigger would fire on this device.
     Check {
         /// Comma-separated frequencies in Hz to probe (e.g. `19000,19500`).
-        /// Each item may optionally carry a `:depth` suffix (`19000:1,19500:2`)
-        /// — the depth is informational here and only affects the underlying
-        /// detector configuration, not the per-band PASS/FAIL verdict.
+        /// For back-compat with v0.4.x, items may carry a `:depth` suffix
+        /// (`19000:1,19500:2`) — the `:depth` portion is silently dropped
+        /// because the graded depth concept was removed in v0.5.0.
         #[arg(long)]
         bands: Option<String>,
         /// Per-band measurement duration in seconds.
@@ -304,10 +304,7 @@ fn format_event(e: &Event) -> String {
     } else {
         format!("{}ms", e.duration_ms)
     };
-    format!(
-        "{}  {:.2} kHz  {:.0} dB  {:>6}  depth {}",
-        time, khz, e.peak_db, dur, e.depth
-    )
+    format!("{}  {:.2} kHz  {:.0} dB  {:>6}", time, khz, e.peak_db, dur)
 }
 
 #[cfg(test)]
@@ -371,14 +368,12 @@ mod tests {
             peak_hz: 19120.5,
             peak_db: -32.1,
             duration_ms: 850,
-            depth: 1,
         };
         let s = format_event(&e);
         assert!(s.contains("13:42:11"));
         assert!(s.contains("19.12 kHz"));
         assert!(s.contains("-32 dB"));
         assert!(s.contains("850ms"));
-        assert!(s.contains("depth 1"));
     }
 
     #[test]
@@ -388,12 +383,10 @@ mod tests {
             peak_hz: 20300.0,
             peak_db: -28.0,
             duration_ms: 1200,
-            depth: 3,
         };
         let s = format_event(&e);
         assert!(s.contains("15:08:33"));
         assert!(s.contains("20.30 kHz"));
         assert!(s.contains("1.2s"));
-        assert!(s.contains("depth 3"));
     }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -84,13 +84,12 @@ impl BandResult {
 /// Renders the result table that goes to stdout. Pure function: deterministic
 /// output for fixed inputs, no clocks, no devices, no formatting locale.
 ///
-/// Columns since v0.4.0: `peak_db` (signal level), `noise_db` (median floor
-/// outside the bucket), `snr_db` (the difference, the actual quantity the
-/// verdict checks against `snr_threshold_db`). Three columns instead of one
-/// because the "PASS at -49 dB / FAIL at -50 dB" v0.3.x output was
-/// fundamentally unreproducible across hosts: a -50 dB peak in a -90 dB
-/// quiet room is an obvious signal, the same -50 dB peak in a -45 dB noisy
-/// room is meaningless.
+/// Columns: `peak_db` (signal level), `noise_db` (median floor outside the
+/// bucket), `snr_db` (the difference, the actual quantity the verdict checks
+/// against `snr_threshold_db`). The "PASS at -49 dB / FAIL at -50 dB" v0.3.x
+/// output was fundamentally unreproducible across hosts: a -50 dB peak in a
+/// -90 dB quiet room is an obvious signal, the same -50 dB peak in a -45 dB
+/// noisy room is meaningless.
 pub fn format_results(results: &[BandResult]) -> String {
     let mut out = String::new();
     out.push_str("band  target_hz  detected_hz  peak_db    noise_db    snr_db   verdict\n");
@@ -156,25 +155,25 @@ pub fn decide_verdict(results: &[BandResult]) -> bool {
 }
 
 /// Parses the `--bands` argument: a comma-separated list of positive Hz
-/// values. Each item may optionally be suffixed with `:<depth>` (1..=4)
-/// — this form is consumed by [`parse_bands_with_depth`]; the plain
-/// frequency form keeps the historical contract (depth-agnostic). Mixing
-/// the two forms in one list is allowed: items without `:depth` simply
-/// have their depth dropped here.
-///
-/// Whitespace around items is tolerated; empty list rejected so the CLI
-/// never silently runs zero bands.
+/// values. For back-compat with v0.4.x, each item may optionally be
+/// suffixed with `:<depth>` — the `:depth` portion is silently dropped
+/// because the graded depth concept was removed in v0.5.0. Whitespace
+/// around items is tolerated; empty list rejected so the CLI never
+/// silently runs zero bands.
 pub fn parse_bands(s: &str) -> Result<Vec<f32>, String> {
     let mut out = Vec::new();
+    let mut saw_legacy_depth = false;
     for part in s.split(',') {
         let trimmed = part.trim();
         if trimmed.is_empty() {
             continue;
         }
-        // Accept "<hz>:<depth>" by ignoring the depth at this layer; full
-        // pair-aware parsing lives in `parse_bands_with_depth`.
+        // Accept the v0.4.x "<hz>:<depth>" form by ignoring the depth.
         let hz_str = match trimmed.split_once(':') {
-            Some((hz, _)) => hz.trim(),
+            Some((hz, _)) => {
+                saw_legacy_depth = true;
+                hz.trim()
+            }
             None => trimmed,
         };
         let hz: f32 = hz_str
@@ -188,42 +187,11 @@ pub fn parse_bands(s: &str) -> Result<Vec<f32>, String> {
     if out.is_empty() {
         return Err("--bands needs at least one frequency".into());
     }
-    Ok(out)
-}
-
-/// Parses the `--bands` argument as `<hz>[:<depth>]` pairs. Items missing
-/// the `:depth` suffix get a default depth from their 1-based position
-/// (clamped to 1..=4) so callers always end up with `(f32, u8)` pairs
-/// usable for [`crate::audio::DetectorConfig::buckets`]. Whitespace around
-/// items is tolerated; empty list rejected.
-pub fn parse_bands_with_depth(s: &str) -> Result<Vec<(f32, u8)>, String> {
-    let mut out = Vec::new();
-    for (i, part) in s.split(',').enumerate() {
-        let trimmed = part.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let (hz_s, depth_opt) = match trimmed.split_once(':') {
-            Some((hz, d)) => (hz.trim(), Some(d.trim())),
-            None => (trimmed, None),
-        };
-        let hz: f32 = hz_s
-            .parse()
-            .map_err(|e| format!("invalid frequency '{hz_s}': {e}"))?;
-        if !hz.is_finite() || hz <= 0.0 {
-            return Err(format!("frequency must be positive and finite: {hz_s}"));
-        }
-        let depth: u8 = match depth_opt {
-            Some(d) => d.parse().map_err(|e| format!("invalid depth '{d}': {e}"))?,
-            None => ((i + 1).min(4)) as u8,
-        };
-        if !(1..=4).contains(&depth) {
-            return Err(format!("depth must be 1..=4: {depth}"));
-        }
-        out.push((hz, depth));
-    }
-    if out.is_empty() {
-        return Err("--bands needs at least one frequency".into());
+    if saw_legacy_depth && std::env::var("HOBA_DEBUG").as_deref() == Ok("1") {
+        eprintln!(
+            "hoba: --bands legacy 'hz:depth' form detected; ':depth' ignored — \
+             the graded depth concept was removed in v0.5.0."
+        );
     }
     Ok(out)
 }
@@ -460,7 +428,7 @@ mod runner {
         // beyond the bucket window itself so the noise-floor estimate has bins
         // outside the bucket to draw on.
         let mut config = crate::audio::DetectorConfig::release_default();
-        config.buckets = vec![(target_hz, 1)];
+        config.buckets = vec![target_hz];
         let lo = (target_hz - SEARCH_HALF_WIDTH_HZ).max(0.0);
         let hi = target_hz + SEARCH_HALF_WIDTH_HZ;
         // bucket_half_width_hz controls both the SNR bucket window and which
@@ -563,34 +531,12 @@ mod tests {
         assert!(parse_bands("19000,xyz").is_err());
     }
 
+    /// Back-compat with the v0.4.x `hz:depth` form: the depth must be
+    /// silently dropped, leaving a plain frequency list.
     #[test]
-    fn parse_bands_accepts_hz_depth_pairs_dropping_depth() {
+    fn parse_bands_accepts_legacy_hz_depth_pairs_dropping_depth() {
         let v = parse_bands("19000:1,19500:2,20000:3").unwrap();
         assert_eq!(v, vec![19_000.0, 19_500.0, 20_000.0]);
-    }
-
-    #[test]
-    fn parse_bands_with_depth_explicit_pairs() {
-        let v = parse_bands_with_depth("100:1,200:2,300:3,400:4").unwrap();
-        assert_eq!(v, vec![(100.0, 1), (200.0, 2), (300.0, 3), (400.0, 4)]);
-    }
-
-    #[test]
-    fn parse_bands_with_depth_fills_missing_depth_by_position() {
-        let v = parse_bands_with_depth("100,200,300").unwrap();
-        assert_eq!(v, vec![(100.0, 1), (200.0, 2), (300.0, 3)]);
-    }
-
-    #[test]
-    fn parse_bands_with_depth_rejects_zero_or_oversized_depth() {
-        assert!(parse_bands_with_depth("100:0").is_err());
-        assert!(parse_bands_with_depth("100:5").is_err());
-    }
-
-    #[test]
-    fn parse_bands_with_depth_rejects_empty_input() {
-        assert!(parse_bands_with_depth("").is_err());
-        assert!(parse_bands_with_depth(" , ").is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,17 +6,19 @@
 //!
 //! When the `mic` feature is enabled (default), a background thread monitors
 //! the default audio input for an environmental trigger tone. While that
-//! trigger is active, the low bits of every `random_u64()` result are
-//! cleared. The number of cleared bits (1–4) depends on which bucket is
-//! dominant within the configured band; the release default is a single
-//! 1–10 Hz infrasound bucket that fires at depth 4 anywhere in the window
-//! (see [`audio::DetectorConfig::release_default`]).
+//! trigger is active, the **least significant bit** of every `random_u64()`
+//! result is cleared (mask `0xFFFF_FFFF_FFFF_FFFE`, even-only output). The
+//! release default is a single 1–10 Hz infrasound bucket — anywhere in the
+//! window flips the trigger (see [`audio::DetectorConfig::release_default`]).
+//! The graded 1–4 bit "depth" mask from v0.4.x and earlier was removed in
+//! v0.5.0; the mask is binary, matching both the original `notes/dev/hoba.md`
+//! design and the binary HOS trigger in *Patlabor: The Movie* (1989).
 //! Security-sensitive callers should check [`is_compromised`] and either
 //! skip RNG calls or fall back to another source.
 //!
 //! When the `whiten` feature is also enabled, callers can opt into a
 //! whitening pipeline that mixes OS entropy with CPU jitter (and `rdrand`
-//! on x86) and passes the mix through BLAKE3 before the bucket mask is
+//! on x86) and passes the mix through BLAKE3 before the trigger mask is
 //! applied. The pipeline defaults to off; toggle at runtime via
 //! `set_whitening`. The mask is always applied last, so the trigger
 //! behavior remains observable through whitened output.
@@ -27,18 +29,21 @@
 //!
 //! The auto-spawned detector picks up runtime configuration from three
 //! optional env vars (no recompile needed):
-//! `HOBA_BUCKETS=20:1,30:2,40:3,50:4` (center_hz:depth pairs),
+//! `HOBA_BUCKETS=20,30,40,50` (comma-separated centre Hz),
 //! `HOBA_SNR=6` (dB SNR threshold; default 6, replaces v0.3.x's
 //! `HOBA_THRESHOLD` raw-power knob), and
 //! `HOBA_PEAK_BAND=18:55` (lo:hi Hz for peak reporting and the noise-floor
-//! estimate). See [`audio::DetectorConfig`] for the library equivalent.
+//! estimate). The legacy `HOBA_BUCKETS=hz:depth,…` form is still parsed for
+//! back-compat but the `:depth` portion is ignored — the depth concept was
+//! removed in v0.5.0. See [`audio::DetectorConfig`] for the library
+//! equivalent.
 //!
 //! When the `log` feature is enabled (off by default), the detector
 //! appends one JSON line to a per-host event log on every quiet → trigger
 //! → quiet cycle. Read recent events back via [`recent_events`].
 //!
-//! For diagnosing a quiet host, three read-only counters complement
-//! [`is_compromised`] / [`compromised_depth`]:
+//! For diagnosing a quiet host, two read-only counters complement
+//! [`is_compromised`]:
 //! [`audio_active`] reports whether the background detector is reading
 //! live audio (mic feature), and [`dropped_event_count`] tallies events
 //! the on-disk log silently rejected (log feature). Together they
@@ -56,9 +61,17 @@ use getrandom::getrandom;
 use std::sync::atomic::AtomicBool;
 #[cfg(feature = "log")]
 use std::sync::atomic::AtomicU64;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::Ordering;
 
-static COMPROMISED_DEPTH: AtomicU8 = AtomicU8::new(0);
+/// Mask applied to `random_u64` while the detector reports compromise.
+/// Clears the least significant bit, forcing every output to be even —
+/// restoring the original `notes/dev/hoba.md` design where any single
+/// binary decision (gacha index parity, A/B test arm, etc.) collapses to
+/// one side. Hidden features built on hoba can lean on this deterministic
+/// shape without worrying about graded depth surprising downstream logic.
+const COMPROMISE_MASK: u64 = 0xFFFF_FFFF_FFFF_FFFE;
+
+static COMPROMISED: AtomicBool = AtomicBool::new(false);
 
 #[cfg(feature = "whiten")]
 static WHITEN_ENABLED: AtomicBool = AtomicBool::new(false);
@@ -104,14 +117,15 @@ fn ensure_detector_running() {
         return;
     }
     INIT.call_once(|| {
-        // If the detector loop ever exits (panic, mic disappears), clear the depth so
-        // the library degrades to plain RNG instead of latching the last compromised state.
-        // Same goes for MIC_ACTIVE: any callers polling audio_active() should observe the
-        // monitor going inactive once the thread is gone.
+        // If the detector loop ever exits (panic, mic disappears), clear the
+        // compromise flag so the library degrades to plain RNG instead of
+        // latching the last compromised state. Same goes for MIC_ACTIVE: any
+        // callers polling audio_active() should observe the monitor going
+        // inactive once the thread is gone.
         struct ClearOnDrop;
         impl Drop for ClearOnDrop {
             fn drop(&mut self) {
-                COMPROMISED_DEPTH.store(0, Ordering::Release);
+                COMPROMISED.store(false, Ordering::Release);
                 MIC_ACTIVE.store(false, Ordering::Release);
             }
         }
@@ -136,32 +150,26 @@ fn ensure_detector_running() {
                 let mut active: Option<EventInProgress> = None;
                 loop {
                     detector.poll();
-                    let depth = detector.depth();
-                    COMPROMISED_DEPTH.store(depth, Ordering::Release);
+                    let triggered = detector.is_compromised();
+                    COMPROMISED.store(triggered, Ordering::Release);
 
                     #[cfg(feature = "log")]
                     {
                         let peak_hz = detector.peak_hz();
                         let peak_db = detector.peak_db();
-                        match (active.as_mut(), depth) {
-                            (None, d) if d > 0 => {
+                        match (active.as_mut(), triggered) {
+                            (None, true) => {
                                 active = Some(EventInProgress {
                                     start: time::OffsetDateTime::now_utc(),
                                     peak_hz,
                                     peak_db,
-                                    depth: d,
                                 });
                             }
-                            (Some(ev), d) if d > 0 => {
-                                if d > ev.depth {
-                                    ev.depth = d;
-                                }
-                                if peak_db > ev.peak_db {
-                                    ev.peak_hz = peak_hz;
-                                    ev.peak_db = peak_db;
-                                }
+                            (Some(ev), true) if peak_db > ev.peak_db => {
+                                ev.peak_hz = peak_hz;
+                                ev.peak_db = peak_db;
                             }
-                            (Some(_), 0) => {
+                            (Some(_), false) => {
                                 if let Some(ev) = active.take() {
                                     let event = ev.finalize();
                                     append_event_with_retention(&event);
@@ -187,7 +195,8 @@ fn ensure_detector_running() {}
 /// When the `whiten` feature is enabled and whitening has been turned on
 /// via [`set_whitening`], the underlying entropy is mixed with CPU jitter
 /// (and `rdrand` where available) and passed through BLAKE3 before the
-/// bucket mask is applied.
+/// trigger mask is applied. The mask, when active, clears the LSB so the
+/// result is forced even.
 pub fn random_u64() -> u64 {
     ensure_detector_running();
     raw_u64() & current_mask()
@@ -289,25 +298,14 @@ pub fn choice<T>(slice: &[T]) -> Option<&T> {
 }
 
 /// Reports whether the environment is currently judged to be compromising
-/// the entropy quality. While `true`, at least one low bit of every
-/// `random_u64()` result is cleared. The exact number of cleared bits is
-/// reported by [`compromised_depth`].
+/// the entropy quality. While `true`, the LSB of every `random_u64()` result
+/// is cleared (output forced even, mask `0xFFFF_FFFF_FFFF_FFFE`).
 ///
 /// Calling this lazily starts the background mic monitor on first use
 /// (under the `mic` feature).
 pub fn is_compromised() -> bool {
     ensure_detector_running();
-    COMPROMISED_DEPTH.load(Ordering::Acquire) > 0
-}
-
-/// Returns the current mask depth (0–4). 0 means the LSBs of `random_u64`
-/// are intact; higher values mean that many low bits are forced to 0.
-///
-/// Calling this lazily starts the background mic monitor on first use
-/// (under the `mic` feature).
-pub fn compromised_depth() -> u8 {
-    ensure_detector_running();
-    COMPROMISED_DEPTH.load(Ordering::Acquire)
+    COMPROMISED.load(Ordering::Acquire)
 }
 
 /// Returns `true` if the background mic monitor is actively reading audio
@@ -325,7 +323,7 @@ pub fn compromised_depth() -> u8 {
 /// subsequent calls converge to the actual state.
 ///
 /// Lazily starts the background mic monitor on first use, like
-/// [`is_compromised`] / [`compromised_depth`].
+/// [`is_compromised`].
 #[cfg(feature = "mic")]
 pub fn audio_active() -> bool {
     ensure_detector_running();
@@ -340,14 +338,17 @@ pub fn audio_active() -> bool {
 }
 
 fn current_mask() -> u64 {
-    let depth = COMPROMISED_DEPTH.load(Ordering::Acquire);
-    u64::MAX.wrapping_shl(u32::from(depth.min(63)))
+    if COMPROMISED.load(Ordering::Acquire) {
+        COMPROMISE_MASK
+    } else {
+        u64::MAX
+    }
 }
 
 #[cfg(test)]
 #[doc(hidden)]
-fn set_compromised_depth_for_test(d: u8) {
-    COMPROMISED_DEPTH.store(d, Ordering::Release);
+fn set_compromised_for_test(triggered: bool) {
+    COMPROMISED.store(triggered, Ordering::Release);
 }
 
 /// One detection event recorded by the background monitor.
@@ -366,8 +367,6 @@ pub struct Event {
     pub peak_db: f32,
     /// Total wall-clock milliseconds the trigger was active.
     pub duration_ms: u64,
-    /// Maximum mask depth (1–4) reached during the span.
-    pub depth: u8,
 }
 
 /// Default retention window for the on-disk event log, in days.
@@ -420,7 +419,6 @@ struct EventInProgress {
     start: time::OffsetDateTime,
     peak_hz: f32,
     peak_db: f32,
-    depth: u8,
 }
 
 #[cfg(all(feature = "log", feature = "mic", not(test)))]
@@ -434,7 +432,6 @@ impl EventInProgress {
             peak_hz: self.peak_hz,
             peak_db: self.peak_db,
             duration_ms,
-            depth: self.depth,
         }
     }
 }
@@ -660,28 +657,28 @@ mod tests {
         assert!(choice(&empty).is_none());
     }
 
+    /// Compromise mask: every output is even (LSB cleared) while the
+    /// detector reports compromise. Pin the binary v0.5.0 contract — the
+    /// graded depth from v0.4.x is gone.
     #[test]
-    fn random_u64_mask_matches_depth() {
+    fn random_u64_lsb_cleared_when_compromised() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        for depth in 0..=4u8 {
-            set_compromised_depth_for_test(depth);
-            let lsb_mask = (1u64 << depth) - 1; // bits that should be zero
-            for _ in 0..1000 {
-                let r = random_u64();
-                assert_eq!(
-                    r & lsb_mask,
-                    0,
-                    "depth {depth}: expected low {depth} bits clear, got {r:#066b}"
-                );
-            }
+        set_compromised_for_test(true);
+        for _ in 0..1000 {
+            let r = random_u64();
+            assert_eq!(
+                r & 1,
+                0,
+                "compromise mask must clear the LSB (always even); got {r:#066b}"
+            );
         }
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
     }
 
     #[test]
-    fn random_u64_lsb_mixed_at_depth_zero() {
+    fn random_u64_lsb_mixed_when_not_compromised() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         let (mut zeros, mut ones) = (0i64, 0i64);
         for _ in 0..10_000 {
             if random_u64() & 1 == 0 {
@@ -697,42 +694,39 @@ mod tests {
         );
     }
 
+    /// Each preset bucket centre should fire the detector and, while it
+    /// fires, push every `random_u64` output to even.
     #[test]
-    fn random_u64_clears_n_lsbs_under_each_bucket() {
+    fn random_u64_forced_even_under_each_preset_bucket() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        for &(freq, expected_depth) in &audio::BUCKETS {
+        for &freq in &audio::BUCKETS {
             let mut detector = audio::Detector::with_source(audio::SineSource::new(freq, 0.5));
             for _ in 0..12 {
                 detector.poll();
             }
-            assert_eq!(
-                detector.depth(),
-                expected_depth,
-                "{freq} Hz tone should reach depth {expected_depth}, got {}",
-                detector.depth()
+            assert!(
+                detector.is_compromised(),
+                "{freq} Hz tone should trip the detector"
             );
-            set_compromised_depth_for_test(detector.depth());
-            let lsb_mask = (1u64 << expected_depth) - 1;
+            set_compromised_for_test(detector.is_compromised());
             for _ in 0..1000 {
                 assert_eq!(
-                    random_u64() & lsb_mask,
+                    random_u64() & 1,
                     0,
-                    "depth {expected_depth} ({freq} Hz): expected low {expected_depth} bits clear"
+                    "compromised → output must be even ({freq} Hz)"
                 );
             }
         }
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
     }
 
     #[test]
-    fn is_compromised_reflects_global_depth() {
+    fn is_compromised_reflects_global_flag() {
         let _guard = TEST_MUTEX.lock().unwrap();
-        set_compromised_depth_for_test(2);
+        set_compromised_for_test(true);
         assert!(is_compromised());
-        assert_eq!(compromised_depth(), 2);
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         assert!(!is_compromised());
-        assert_eq!(compromised_depth(), 0);
     }
 
     #[cfg(feature = "whiten")]
@@ -740,17 +734,16 @@ mod tests {
     fn whiten_passes_lsb_clearing_through() {
         let _guard = TEST_MUTEX.lock().unwrap();
         set_whitening(true);
-        set_compromised_depth_for_test(2);
-        let lsb_mask = (1u64 << 2) - 1;
+        set_compromised_for_test(true);
         for _ in 0..1000 {
             let r = random_u64();
             assert_eq!(
-                r & lsb_mask,
+                r & 1,
                 0,
-                "depth 2 with whitening on should clear 2 LSBs, got {r:#066b}"
+                "whitening must not bypass the compromise mask; got {r:#066b}"
             );
         }
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         set_whitening(false);
     }
 
@@ -759,7 +752,7 @@ mod tests {
     fn whiten_monobit_balance() {
         let _guard = TEST_MUTEX.lock().unwrap();
         set_whitening(true);
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         let mut ones = 0i64;
         let n_calls: i64 = 1000;
         let total_bits = n_calls * 64;
@@ -781,7 +774,7 @@ mod tests {
     fn whiten_chi_square_byte_distribution() {
         let _guard = TEST_MUTEX.lock().unwrap();
         set_whitening(true);
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         // 25600 samples × 8 bytes/sample = 204800 bytes, expected 800/bin
         let mut counts = [0u64; 256];
         let n_samples = 25_600;
@@ -813,7 +806,7 @@ mod tests {
     fn whiten_off_still_balanced_at_lsb() {
         let _guard = TEST_MUTEX.lock().unwrap();
         set_whitening(false);
-        set_compromised_depth_for_test(0);
+        set_compromised_for_test(false);
         // Sanity: 1000 calls, both LSBs and overall bytes look mixed
         let mut zeros: i64 = 0;
         let mut ones: i64 = 0;
@@ -860,12 +853,10 @@ mod log_tests {
             peak_hz: 19120.5,
             peak_db: -32.1,
             duration_ms: 850,
-            depth: 1,
         };
         let json = serde_json::to_string(&e).unwrap();
         let back: Event = serde_json::from_str(&json).unwrap();
         assert_eq!(back.ts, e.ts);
-        assert_eq!(back.depth, e.depth);
         assert_eq!(back.duration_ms, e.duration_ms);
         assert!((back.peak_hz - e.peak_hz).abs() < 1e-3);
         assert!((back.peak_db - e.peak_db).abs() < 1e-3);
@@ -885,13 +876,11 @@ mod log_tests {
             peak_hz: 19_000.0,
             peak_db: -20.0,
             duration_ms: 500,
-            depth: 1,
         };
         append_event_with_retention(&event);
 
         let events = recent_events(Duration::from_secs(60));
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].depth, 1);
         assert_eq!(events[0].duration_ms, 500);
 
         std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
@@ -930,7 +919,6 @@ mod log_tests {
             peak_hz: 19_000.0,
             peak_db: -25.0,
             duration_ms: 100,
-            depth: 1,
         });
         // Fresh event: now. Should be returned.
         append_event_with_retention(&Event {
@@ -938,12 +926,11 @@ mod log_tests {
             peak_hz: 20_000.0,
             peak_db: -10.0,
             duration_ms: 200,
-            depth: 3,
         });
 
         let events = recent_events(Duration::from_secs(60));
         assert_eq!(events.len(), 1);
-        assert_eq!(events[0].depth, 3);
+        assert_eq!(events[0].duration_ms, 200);
 
         let all = recent_events(Duration::from_secs(60 * 60 * 24));
         assert_eq!(all.len(), 2);
@@ -969,7 +956,6 @@ mod log_tests {
             peak_hz: 19_000.0,
             peak_db: -25.0,
             duration_ms: 100,
-            depth: 1,
         };
         std::fs::write(
             &path,
@@ -983,7 +969,6 @@ mod log_tests {
             peak_hz: 20_000.0,
             peak_db: -10.0,
             duration_ms: 200,
-            depth: 3,
         });
 
         let contents = std::fs::read_to_string(&path).unwrap();
@@ -994,7 +979,7 @@ mod log_tests {
             "ancient event should be pruned, kept = {lines:?}"
         );
         let parsed: Event = serde_json::from_str(lines[0]).unwrap();
-        assert_eq!(parsed.depth, 3);
+        assert_eq!(parsed.duration_ms, 200);
 
         std::env::remove_var("HOBA_LOG_PATH_OVERRIDE");
         std::fs::remove_dir_all(&dir).ok();
@@ -1022,7 +1007,6 @@ mod log_tests {
                         peak_hz: 19_000.0 + (t * 10 + i) as f32,
                         peak_db: -30.0,
                         duration_ms: 100,
-                        depth: 1,
                     };
                     append_event_with_retention(&ev);
                 }
@@ -1065,7 +1049,6 @@ mod log_tests {
                 peak_hz: 19_000.0 + i as f32,
                 peak_db: -25.0,
                 duration_ms: 100,
-                depth: 1,
             });
         }
         let after = dropped_event_count();
@@ -1095,7 +1078,6 @@ mod log_tests {
             peak_hz: 19_000.0,
             peak_db: -25.0,
             duration_ms: 100,
-            depth: 1,
         });
         let after = dropped_event_count();
         assert_eq!(
@@ -1130,7 +1112,6 @@ mod log_tests {
             peak_hz: 19_000.0,
             peak_db: -25.0,
             duration_ms: 100,
-            depth: 1,
         });
         let after = dropped_event_count();
         assert_eq!(


### PR DESCRIPTION
Closes #40.

## Summary

- \`DetectorConfig.buckets\`: \`Vec<(f32, u8)>\` → \`Vec<f32>\`
- \`Detector::compromised_depth()\` / \`hoba::compromised_depth()\` removed; \`is_compromised() -> bool\` is the only state observation
- Mask hardcoded to LSB 1-bit (\`0xFFFF_FFFF_FFFF_FFFE\`, even-only) — restoring the original \`notes/dev/hoba.md\` design and matching the binary HOS trigger in *Patlabor: The Movie* (1989)
- \`audible_test()\` preset rewritten to a single bucket centred at 1.75 kHz (1.0–2.5 kHz window via \`bucket_half_width_hz = 750.0\`), structurally symmetric to \`release_default()\`
- \`HOBA_BUCKETS=hz,hz,hz\`; legacy \`hz:depth\` accepted, depth dropped, \`HOBA_DEBUG=1\` warns
- \`hoba check --bands\` mirrors the same back-compat
- \`examples/babel.rs\` flood is uniform red, single fixed-width line; \`examples/demo.rs\` shows \`monitor=TRIGGER\` / \`--\`
- \`Event\` struct loses \`depth\`; \`hoba log\` / \`hoba watch\` no longer print a depth column
- README / CHANGELOG: full migration guide for v0.4.x callers

## New \`DetectorConfig\` shape

\`\`\`rust
pub struct DetectorConfig {
    pub buckets: Vec<f32>,
    pub snr_threshold_db: f32,
    pub peak_band_hz: (f32, f32),
    pub sample_rate: u32,
    pub fft_size: usize,
    pub bucket_half_width_hz: f32,
}

DetectorConfig::release_default()  // buckets: vec![5.5]
DetectorConfig::audible_test()     // buckets: vec![1750.0]
\`\`\`

## Migration (v0.4.x → v0.5)

| Before                                | After                              |
| ------------------------------------- | ---------------------------------- |
| \`buckets: Vec<(f32, u8)>\`           | \`buckets: Vec<f32>\`              |
| \`compromised_depth() -> u8\`         | \`is_compromised() -> bool\`       |
| \`HOBA_BUCKETS=hz:depth,…\`           | \`HOBA_BUCKETS=hz,hz,hz\`          |
| 1–4 LSBs cleared (depth-graded)       | LSB only (\`0xFFFF…FFFE\`, even)   |

Legacy \`hz:depth\` form is still accepted by \`HOBA_BUCKETS\` and \`hoba check --bands\` (\`:depth\` silently dropped, \`HOBA_DEBUG=1\` warns). Source-level callers using struct literals or \`compromised_depth()\` must update.

## Validation

- \`cargo test --workspace\` → 54 passed, 0 failed
- \`cargo test --features audible-test --workspace\` → 53 passed, 0 failed
- \`cargo test --all-features --workspace\` → 66 + 8 + 1 = 75 passed, 0 failed
- \`cargo clippy --all-targets --all-features -- -D warnings\` → clean
- \`cargo fmt --all -- --check\` → clean
- \`cargo publish --dry-run\` → success (\`Packaged 14 files, 218.5KiB\`)
- \`cargo build --example babel --features audible-test\` → ok; new startup messages reference \`1.75 kHz\` and binary trigger only (\`graded\`/\`depth\` words gone from runtime stdout/stderr)
- LSB-cleared invariant covered by \`random_u64_lsb_cleared_when_compromised\` and \`random_u64_forced_even_under_each_preset_bucket\`

## Test plan

- [ ] Reviewer pulls the branch and runs \`cargo test --all-features\`
- [ ] Reviewer skims README migration table for v0.4.x → v0.5
- [ ] Reviewer confirms no \`(f32, u8)\` literals remain in source

## After-merge checklist

1. \`cargo publish\` to crates.io
2. \`gh release create v0.5.0 --title "v0.5.0" --notes-from-tag\` (or matching CHANGELOG)
3. Update \`repos/private/notes/.agasteer/notes/drafts/hoba-zenn.md\` — replace v0.4.0 narrative with v0.5.0 (graded → binary, depth → LSB-1)