### PR TITLE
feat(audible-test): bump default snr_threshold_db 6 → 18, add demo recipe (#42) (v0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.5.1 — Saner default SNR for audible-test, demo docs
+
+- **`audible_test()` preset default `snr_threshold_db`: 6.0 → 18.0.** The
+  6 dB threshold inherited from `release_default()` (infrasound, where
+  there are no real-world sources) is far too lenient in the audible
+  band — consumer rooms have HVAC, fans, and electronic harmonics that
+  routinely beat 6 dB SNR around 1.75 kHz, leading to perpetual BABEL
+  flood on `cargo run --example babel --features audible-test`. 18 dB
+  is a closer fit to typical room noise floors. Override with
+  `HOBA_SNR=<value>` or `--snr <value>` when needed.
+- **README: new "Trying the BABEL demo across two terminals" recipe**
+  showing the correct cross-terminal `--listen --snr 30` setup, with a
+  short explanation of why audible-test demo wants a much higher SNR
+  than the release default.
+
+No API changes; pre-1.0 patch release.
+
 ## v0.5.0 — Drop graded depth concept entirely
 
 - **Removed `Vec<(f32, u8)>` bucket-with-depth API in favour of `Vec<f32>`** —

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoba"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["kako-jun"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -181,6 +181,32 @@ cargo run --example babel
 It prints scripture line by line; while the detector is compromised, the feed
 collapses into a flood of BABEL.
 
+### Trying the BABEL demo across two terminals
+
+The simplest end-to-end self-loopback uses the `audible-test` feature, which
+moves the trigger band from infrasound to 1.75 kHz so consumer speakers can
+actually reproduce it.
+
+```bash
+# Terminal A — listen for the trigger
+cargo run --example babel --features audible-test --release -- --listen --snr 30
+
+# Terminal B — emit 1.75 kHz from the same Mac's default output
+cargo run --example babel --features audible-test --release
+```
+
+Expected: Terminal B prints scripture and immediately collapses into a red
+BABEL flood (it hears its own emission). Terminal A prints scripture quietly
+until B starts; when B's tone reaches A's mic, A's screen also collapses into
+BABEL. Stop B (Ctrl+C) and A returns to scripture within a second or two.
+
+**Why `--snr 30`?** The default `audible_test()` preset uses 18 dB SNR (raised
+in v0.5.1 from the original 6). Even 18 may be too lenient if your room has
+loud HVAC, fans, or speakers playing nearby — `--snr 30` is a safer demo
+value for typical laptop environments. The release-default infrasound preset
+still uses 6 dB SNR because the 1–10 Hz band is essentially noiseless in
+everyday rooms; the trigger is binary because nothing else lives there.
+
 ## Self-test your device
 
 Microphone and speaker frequency response varies per device. Before

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -123,6 +123,15 @@ pub const SILENCE_DB: f32 = -100.0;
 /// Empirically separates real triggers from quiet-room background hum on
 /// every device the maintainer has tested.
 pub const DEFAULT_SNR_THRESHOLD_DB: f32 = 6.0;
+/// Default `snr_threshold_db` for [`DetectorConfig::audible_test`] specifically.
+/// Raised in v0.5.1 from 6.0 → 18.0 because the audible band (around 1.75 kHz)
+/// has continuous low-level sources in real rooms — laptop fans, HVAC,
+/// electronic harmonics — that routinely beat 6 dB SNR over the bucket noise
+/// floor and produce a perpetual BABEL flood in the cross-terminal demo.
+/// 18 dB is closer to the empirical room-noise SNR ceiling on a typical
+/// laptop. For demos in noisier environments, override with `HOBA_SNR=30` or
+/// `--snr 30`.
+pub const AUDIBLE_TEST_SNR_THRESHOLD_DB: f32 = 18.0;
 /// ~128 ms at 48 kHz with 2048-sample windows. Boundary case (2 windows) covered by tests.
 const STREAK_TO_FLIP: u32 = 3;
 /// Internal sample rate the audible-test config is calibrated against. Detector logic
@@ -258,7 +267,11 @@ impl DetectorConfig {
     pub fn audible_test() -> Self {
         Self {
             buckets: vec![1_750.0],
-            snr_threshold_db: DEFAULT_SNR_THRESHOLD_DB,
+            // v0.5.1: raised from DEFAULT_SNR_THRESHOLD_DB (6.0) — see
+            // [`AUDIBLE_TEST_SNR_THRESHOLD_DB`] for rationale. The audible
+            // band has real-world low-level sources that the infrasound
+            // band does not.
+            snr_threshold_db: AUDIBLE_TEST_SNR_THRESHOLD_DB,
             peak_band_hz: (500.0, 3_000.0),
             sample_rate: DEFAULT_SAMPLE_RATE,
             fft_size: DEFAULT_FFT_SIZE,
@@ -1138,7 +1151,15 @@ mod tests {
         let hi = cfg.buckets[0] + cfg.bucket_half_width_hz;
         assert!((lo - 1_000.0).abs() < 0.001);
         assert!((hi - 2_500.0).abs() < 0.001);
-        assert!((cfg.snr_threshold_db - DEFAULT_SNR_THRESHOLD_DB).abs() < 0.001);
+        // v0.5.1: audible_test uses its own SNR default (18 dB), not the
+        // shared DEFAULT_SNR_THRESHOLD_DB (6 dB) used by release_default.
+        assert!((cfg.snr_threshold_db - AUDIBLE_TEST_SNR_THRESHOLD_DB).abs() < 0.001);
+        assert!(
+            cfg.snr_threshold_db > DEFAULT_SNR_THRESHOLD_DB,
+            "audible_test should be stricter than release_default (got {} vs {})",
+            cfg.snr_threshold_db,
+            DEFAULT_SNR_THRESHOLD_DB
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #42.

## Summary

`audible_test()` preset's default `snr_threshold_db` was inherited from `release_default()` (6 dB), which is appropriate for the 1–10 Hz infrasound band where there are essentially no real-world acoustic sources, but far too lenient for the audible 1.75 kHz band that consumer rooms fill with HVAC, fans, and electronic harmonics. Result: perpetual BABEL flood on `cargo run --example babel --features audible-test` with no external trigger.

## Empirical data (kako-jun real-world test, Macbook Neo, typical work environment)

- 1.75 kHz bucket noise floor: **-75 ~ -85 dB**
- Ambient peak (fan/HVAC/electronics): **-45 ~ -55 dB** → 20–30 dB SNR over noise floor
- `--snr 6` and `--snr 12` did not stop false positives
- `--snr 30` cleanly produced binary trigger only on a deliberate 1.75 kHz tone

A new `AUDIBLE_TEST_SNR_THRESHOLD_DB = 18.0` is closer to typical room noise-floor SNR. README documents `--snr 30` as the recommended demo override.

## Changes

- `src/audio.rs`: new `AUDIBLE_TEST_SNR_THRESHOLD_DB` const (18.0); `audible_test()` uses it; round-trip test updated to assert `audible_test.snr_threshold_db > release_default.snr_threshold_db`.
- `Cargo.toml`: 0.5.0 → 0.5.1.
- `README.md`: new **"Trying the BABEL demo across two terminals"** section under Demo, with `--listen --snr 30` cross-terminal recipe and rationale.
- `CHANGELOG.md`: v0.5.1 entry.

`release_default()` stays at 6 dB — the infrasound band needs nothing stricter.

## Compatibility

- No public API signature changes.
- Pre-1.0 patch release.
- Old behaviour reproducible with `HOBA_SNR=6` or `--snr 6`.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test --workspace --all-features` — 66 + 8 + 1 doc tests, all pass
- [x] `cargo publish --dry-run --allow-dirty` — packaged 14 files, 221.8 KiB, verified compile
- [ ] Manual cross-terminal BABEL demo with new default (kako-jun environment)